### PR TITLE
Fix database creation error

### DIFF
--- a/plugin/src/TransbankWebpayOrders.php
+++ b/plugin/src/TransbankWebpayOrders.php
@@ -15,7 +15,7 @@ class TransbankWebpayOrders
     const STATUS_APPROVED = 'approved';
 
     const TABLE_VERSION_OPTION_KEY = 'webpay_orders_table_version';
-    const LATEST_TABLE_VERSION = 1;
+    const LATEST_TABLE_VERSION = 2;
     /**
      * @return string
      */


### PR DESCRIPTION
This fix an issue that prevented that the new rest transactions table gets created when the user  had the soap version of the plugin installed before installing this version

Now its gets created automatically
![image](https://user-images.githubusercontent.com/1103494/101084617-f9593a00-358c-11eb-8445-4c16d80ebfe7.png)
