### PR TITLE
Extensión de soporte a temas desarrollados en wordpress con el plugin timber

### DIFF
--- a/plugin/src/Helpers/RedirectorHelper.php
+++ b/plugin/src/Helpers/RedirectorHelper.php
@@ -20,6 +20,6 @@ class RedirectorHelper
     public static function redirect($url, array $data)
     {
         echo static::getRedirectForm($url, $data);
-        die;
+        return;
     }
 }


### PR DESCRIPTION
Corrección de compatibilidad entre transbank y el plugin timber (motor de plantillas), al momento de ir a la página checkout y tratar de finalizar el pago con el método de pago webpay, retornaba una página en blanco, esto es debido al die que está en la función de redireccionamiento de transbank, debido a que detenía la ejecución de procesos posteriores. Al cambiar este die por un return, el proceso se ejecuta correctamente y sin problemas.