### PR TITLE
Prepare release 1.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Para generar una nueva versión, se debe crear un PR (con un título "Prepare re
 En ese PR deben incluirse los siguientes cambios:
 
 1. Modificar el archivo `plugin/readme.txt` para incluir una nueva entrada (al comienzo) para `X.Y.Z` que explique en español los cambios. (bajo el título == Changelog ==)
+2. Modificar el archivo `plugin/readme.txt` para incluir una nueva entrada en la sección == Upgrade Notice == con una explicación breve de porque se debe actualizar.
 
 Luego de obtener aprobación del pull request, debes mezclar a master e inmediatamente generar un release en GitHub con el tag `vX.Y.Z`. En la descripción del release debes poner lo mismo que agregaste al changelog.
 Con eso Travis CI generará automáticamente una nueva versión del plugin y actualizará el Release de Github con el zip del plugin, además de crear el release en el SVN de Wordpress.org.

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -14,6 +14,9 @@ Recibe pagos en línea con tarjetas de crédito, débito y prepago en tu WooComm
 Recibe pagos en línea con tarjetas de crédito, débito y prepago en tu WooCommerce a través de Webpay Plus.
 
 == Changelog ==
+= 1.3.1 =
+* Se cambia la posición del menú "Webpay Plus" que antes estaba en el menú principal y ahora bajo el menú WooCommerce
+
 = 1.3.0 =
 Agregado:
 * Se reemplaza el modal de diagnóstico por pantallas especiales
@@ -49,6 +52,9 @@ Arreglado:
 * Initial release.
 
 == Upgrade Notice ==
+= 1.3.1 =
+* Se cambia la posición del menú "Webpay Plus" que antes estaba en el menú principal y ahora bajo el menú WooCommerce
+
 = 1.3.0 =
 Agregado:
 * Se reemplaza el modal de diagnóstico por pantallas especiales


### PR DESCRIPTION
You can see the full diff [here](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/compare/1.3.0...chore/prepare-release-1.3.1)