### PR TITLE
Prepare release 1.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Para poder operar con dinero real (ambiente de **producción**), debes completar
 A continuación, encontrarás información necesaria para el desarrollo de este plugin. 
 
 ## Requisitos 
-* PHP 5.6 o superior
+* PHP 7.0 o superior
 * Woocommerce 3.4 o superior
 
 ## Dependencias
 
 El plugin depende de las siguientes librerías:
 
-* transbank/transbank-sdk
+* transbank/transbank-sdk:~2.0
 * tecnickcom/tcpdf
 * apache/log4php
 
@@ -47,7 +47,6 @@ Para cumplir estas dependencias, debes instalar [Composer](https://getcomposer.o
 Para apoyar el levantamiento rápido de un ambiente de desarrollo, hemos creado la especificación de contenedores a través de Docker Compose.
 
 Para testear los ejemplos estos estan disponibles en:
-- [WooCommerce 3.4.0 con php 5.6](./docker-woocommerce-php5.6)
 - [WooCommerce 3.4.0 con php 7.1](./docker-woocommerce-php7.1)
 - [WooCommerce 3.6.3 con php 7.2](./docker-woocommerce-php7.2)
 - [WooCommerce 3.9.1 con php 7.3](./docker-woocommerce-php7.3)

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -14,6 +14,15 @@ Recibe pagos en línea con tarjetas de crédito, débito y prepago en tu WooComm
 Recibe pagos en línea con tarjetas de crédito, débito y prepago en tu WooCommerce a través de Webpay Plus.
 
 == Changelog ==
+= 1.4.0 =
+* Se utiliza el nuevo SDk de PHP versión 2.0
+* Ya no es compatible con PHP 5.6.
+* Ahora es compatible de PHP 7.0 a PHP 8.0
+* Ahora se puede completar el formulario de validación directamente desde el plugin
+* Se soluciona warning de jQuery [PR 57](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/pull/57)
+* Se aplica coding style de StyleCI.
+
+
 = 1.3.4 =
 * Se mejora compatibilidad con PHP 7.0
 * El plugin ya no debería fallar si no existe la extensión ext-soap de PHP
@@ -66,6 +75,10 @@ Arreglado:
 * Initial release.
 
 == Upgrade Notice ==
-= 1.3.4 =
-* Se mejora compatibilidad con PHP 7.0
-* El plugin ya no debería fallar si no existe la extensión ext-soap de PHP
+= 1.4.0 =
+* Se utiliza el nuevo SDk de PHP versión 2.0
+* Ya no es compatible con PHP 5.6.
+* Ahora es compatible de PHP 7.0 a PHP 8.0
+* Ahora se puede completar el formulario de validación directamente desde el plugin
+* Se soluciona warning de jQuery [PR 57](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/pull/57)
+* Se aplica coding style de StyleCI.

--- a/plugin/views/admin/logs.php
+++ b/plugin/views/admin/logs.php
@@ -93,12 +93,12 @@ if (!defined('ABSPATH')) {
                     <strong>Peso del Documento: </strong></td>
                 <td class="tbk_table_td">
                     <?php echo isset(json_decode(
-                                $log->getLastLog(),
-                                true
-                            )['log_weight']) ? json_decode(
                             $log->getLastLog(),
                             true
-                        )['log_weight'] : null; ?>
+                        )['log_weight']) ? json_decode(
+                                $log->getLastLog(),
+                                true
+                            )['log_weight'] : null; ?>
                 </td>
             </tr>
             <tr>
@@ -109,12 +109,12 @@ if (!defined('ABSPATH')) {
                     <strong>Cantidad de Líneas: </strong></td>
                 <td class="tbk_table_td">
                     <?php echo isset(json_decode(
-                                $log->getLastLog(),
-                                true
-                            )['log_regs_lines']) ? json_decode(
                             $log->getLastLog(),
                             true
-                        )['log_regs_lines'] : null; ?>
+                        )['log_regs_lines']) ? json_decode(
+                                $log->getLastLog(),
+                                true
+                            )['log_regs_lines'] : null; ?>
                 </td>
             </tr>
         </table>
@@ -123,12 +123,12 @@ if (!defined('ABSPATH')) {
                     <span
                         style="font-size: 10px; font-family:monospace; display: block; background: white;width: fit-content;">
                     <?php echo isset(json_decode(
-                                $log->getLastLog(),
-                                true
-                            )['log_content']) ? json_decode(
                             $log->getLastLog(),
                             true
-                        )['log_content'] : null; ?>
+                        )['log_content']) ? json_decode(
+                                $log->getLastLog(),
+                                true
+                            )['log_content'] : null; ?>
                     </span>
                 </pre>
     </fieldset>


### PR DESCRIPTION
= 1.4.0 =
* Se utiliza el nuevo SDk de PHP versión 2.0
* Ya no es compatible con PHP 5.6.
* Ahora es compatible de PHP 7.0 a PHP 8.0
* Ahora se puede completar el formulario de validación directamente desde el plugin
* Se soluciona warning de jQuery [PR 57](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/pull/57)
* Se aplica coding style de StyleCI.