### PR TITLE
Add webpay commerce code and environment to oneclick singup link

### DIFF
--- a/plugin/composer.lock
+++ b/plugin/composer.lock
@@ -798,16 +798,16 @@
         },
         {
             "name": "transbank/transbank-sdk",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TransbankDevelopers/transbank-sdk-php.git",
-                "reference": "711f52a290cb4e6fc2466e983c2cc75b82b6acba"
+                "reference": "17e824a0079c6b296383abc3b7d1e681b77a5ec5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TransbankDevelopers/transbank-sdk-php/zipball/711f52a290cb4e6fc2466e983c2cc75b82b6acba",
-                "reference": "711f52a290cb4e6fc2466e983c2cc75b82b6acba",
+                "url": "https://api.github.com/repos/TransbankDevelopers/transbank-sdk-php/zipball/17e824a0079c6b296383abc3b7d1e681b77a5ec5",
+                "reference": "17e824a0079c6b296383abc3b7d1e681b77a5ec5",
                 "shasum": ""
             },
             "require": {
@@ -843,9 +843,9 @@
             ],
             "support": {
                 "issues": "https://github.com/TransbankDevelopers/transbank-sdk-php/issues",
-                "source": "https://github.com/TransbankDevelopers/transbank-sdk-php/tree/2.0.5"
+                "source": "https://github.com/TransbankDevelopers/transbank-sdk-php/tree/2.0.6"
             },
-            "time": "2021-07-06T19:14:18+00:00"
+            "time": "2021-07-12T21:51:21+00:00"
         }
     ],
     "packages-dev": [],

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -1,9 +1,9 @@
 === Transbank Webpay Plus REST ===
 Contributors: TransbankDevelopers
-Tags: transbank, webpay, rest, chile
+Tags: transbank, webpay, oneclick, webpay plus, rest, chile
 Requires at least: 4.0
-Tested up to: 5.6
-Requires PHP: 5.6
+Tested up to: 5.8
+Requires PHP: 7.0
 Stable tag: VERSION_REPLACE_HERE
 License: 3-Clause BSD License
 License URI: https://opensource.org/licenses/BSD-3-Clause

--- a/plugin/src/Controllers/OneclickInscriptionResponseController.php
+++ b/plugin/src/Controllers/OneclickInscriptionResponseController.php
@@ -24,7 +24,6 @@ class OneclickInscriptionResponseController
         $this->gatewayId = $gatewayId;
     }
 
-
     /**
      * @throws \Transbank\WooCommerce\WebpayRest\Exceptions\TokenNotFoundOnDatabaseException
      */
@@ -32,7 +31,7 @@ class OneclickInscriptionResponseController
     {
         $this->logger->logInfo('[ONECLICK] Process inscription return: GET '.print_r($_GET, true).' | POST: '.print_r($_POST, true));
         if ($this->transactionWasTimeout()) {
-            $this->logger->logError('[ONECLICK] Timeout Error' . print_r($_GET, true)  . print_r($_POST, true));
+            $this->logger->logError('[ONECLICK] Timeout Error'.print_r($_GET, true).print_r($_POST, true));
             wc_add_notice('La transacción fue cancelada automáticamente por estar inactivo mucho tiempo en el formulario de pago de Webpay. Puede reintentar el pago', 'error');
             wp_redirect(wc_get_checkout_url());
             exit;
@@ -146,7 +145,6 @@ class OneclickInscriptionResponseController
 
         $this->redirectUser($from);
     }
-
 
     /**
      * @return bool

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -401,6 +401,7 @@ class ResponseController
 
         return $paymentType;
     }
+
     /**
      * @param string $msg
      */

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -53,7 +53,7 @@ class ResponseController
     public function response($postData)
     {
         if ($this->transactionWasTimeout()) {
-            $this->throwError('La transacción fue cancelada automáticamente por estar inactivo mucho tiempo en el formulario de pago de Webpay. ');
+            $this->throwError('La transacción fue cancelada automáticamente por estar inactivo mucho tiempo en el formulario de pago de Webpay. Puede reintentar el pago');
             wp_redirect(wc_get_checkout_url());
             exit;
         }

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -52,7 +52,13 @@ class ResponseController
      */
     public function response($postData)
     {
+        if ($this->transactionWasTimeout()) {
+            $this->throwError('La transacción fue cancelada automáticamente por estar inactivo mucho tiempo en el formulario de pago de Webpay. ');
+            wp_redirect(wc_get_checkout_url());
+            exit;
+        }
         $token_ws = $this->getTokenWs($postData);
+
         $webpayTransaction = Transaction::getByToken($token_ws);
 
         $wooCommerceOrder = $this->getWooCommerceOrderById($webpayTransaction->order_id);
@@ -118,6 +124,8 @@ class ResponseController
         $token_ws = isset($data['token_ws']) ? $data['token_ws'] : (isset($data['TBK_TOKEN']) ? $data['TBK_TOKEN'] : null);
         if (!isset($token_ws)) {
             $this->throwError('No se encontró el token');
+            wp_redirect(wc_get_checkout_url());
+            exit;
         }
 
         return $token_ws;
@@ -133,13 +141,6 @@ class ResponseController
         $wooCommerceOrder = new WC_Order($orderId);
 
         return $wooCommerceOrder;
-    }
-
-    protected function throwError($msg)
-    {
-        $error_message = 'Estimado cliente, le informamos que su orden termin&oacute; de forma inesperada: <br />'.$msg;
-        wc_add_notice(__('ERROR: ', 'transbank_wc_plugin').$error_message, 'error');
-        exit();
     }
 
     /**
@@ -320,6 +321,18 @@ class ResponseController
     }
 
     /**
+     * @return bool
+     */
+    private function transactionWasTimeout()
+    {
+        $buyOrder = $_POST['TBK_ORDEN_COMPRA'] ?? $_GET['TBK_ORDEN_COMPRA'] ?? null;
+        $sessionId = $_POST['TBK_ID_SESION'] ?? $_GET['TBK_ID_SESION'] ?? null;
+        $token = $_POST['TBK_TOKEN'] ?? $_GET['TBK_TOKEN'] ?? null;
+
+        return $buyOrder && $sessionId && !$token;
+    }
+
+    /**
      * @param $amount
      * @param array $result
      * @param $sharesAmount
@@ -387,5 +400,13 @@ class ResponseController
         }
 
         return $paymentType;
+    }
+    /**
+     * @param string $msg
+     */
+    protected function throwError(string $msg)
+    {
+        $error_message = __($msg);
+        wc_add_notice($error_message, 'error');
     }
 }

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -22,7 +22,6 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
     use TransbankRESTPaymentGateway;
 
     const WOOCOMMERCE_API_RETURN_ADD_PAYMENT = 'wc_gateway_transbank_oneclick_return_payments';
-    const WOOCOMMERCE_API_RETURN_ADD_PAYMENT_CHECKOUT = 'wc_gateway_transbank_oneclick_return_payment_checkout';
     /**
      * @var Oneclick\MallInscription
      */

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -335,14 +335,14 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
             'commerce_code' => [
                 'title'       => __('Código de Comercio Mall Producción', 'transbank_wc_plugin'),
                 'placeholder' => 'Ej: 597012345678',
-                'description' => 'Indica tu código de comercio para el ambiente de producción. Este se te entregará al completar el proceso de afiliación comercial. Siempre comienza con 5970 y debe tener 12 dígitos. Si el tuyo tiene 8, antepone 5970. ',
+                'description' => 'Ingresa tu código de comercio Mall para el ambiente de producción. Este se te entregará al completar el proceso de afiliación comercial. Siempre comienza con 5970 y debe tener 12 dígitos. Si el tuyo tiene 8, antepone 5970. ',
                 'type'        => 'text',
                 'default'     => '',
             ],
             'child_commerce_code' => [
                 'title'       => __('Código de Comercio Tienda Producción', 'transbank_wc_plugin'),
                 'placeholder' => 'Ej: 597012345678',
-                'description' => 'Indica tu código de comercio para el ambiente de producción. Este se te entregará al completar el proceso de afiliación comercial. Siempre comienza con 5970 y debe tener 12 dígitos. Si el tuyo tiene 8, antepone 5970. ',
+                'description' => 'Indica tu código de comercio Tienda para el ambiente de producción. Este se te entregará al completar el proceso de afiliación comercial. Siempre comienza con 5970 y debe tener 12 dígitos. Si el tuyo tiene 8, antepone 5970. ',
                 'type'        => 'text',
                 'default'     => '',
             ],

--- a/plugin/views/admin/oneclick-admin-options.php
+++ b/plugin/views/admin/oneclick-admin-options.php
@@ -2,12 +2,15 @@
 if (!defined('ABSPATH')) {
     exit;
 }
+$webpayPlus = new WC_Gateway_Transbank_Webpay_Plus_REST();
+$webpayPlusEnvironment = $webpayPlus->get_option('webpay_rest_environment');
+$webpayPlusCommerceCode = $webpayPlus->get_option('webpay_rest_commerce_code');
 ?>
 
 <hr>
 
 <div style="clear: both">
-    <a target="_blank" href="https://contrata.transbankdevelopers.cl/?utm_source=woocommerce_plugin">
+    <a target="_blank" href="https://contrata.transbankdevelopers.cl/?wpcommerce=<?php echo $webpayPlusCommerceCode; ?>&wpenv=<?php echo $webpayPlusEnvironment; ?>&utm_source=woocommerce_plugin&utm_medium=banner&utm_campaign=contrata">
         <img style="border-radius: 10px; width: 800px; display: block" src="<?php echo plugins_url('/images/oneclick-banner.jpg', dirname(__DIR__)); ?>" alt="">
     </a>
 </div>

--- a/plugin/views/admin/oneclick-admin-options.php
+++ b/plugin/views/admin/oneclick-admin-options.php
@@ -16,6 +16,18 @@ $webpayPlusCommerceCode = $webpayPlus->get_option('webpay_rest_commerce_code');
 </div>
 
 
+<div style="max-width: 760px; margin: 20px 0; background: #fff; border-radius: 10px; padding: 20px; display:inline-block">
+    <h3>Webpay Oneclick Mall</h3>
+    <p>Este plugin funciona con Oneclick en modalidad MALL. Esto significa que tienes un <strong>código de comercio
+    Mall</strong> que puede tener uno o varios códigos de comercio tienda o "hijos". Cuando un usuario inscribe su
+    tarjeta, lo hace asociado su tarjeta al código de comercio Mall, pero cuando se realiza una transacción
+    (autorización) esta es realizada por una (o más) tiendas del Mall. En el fondo, el dinero de esa transacción
+    se pagará al código de comercio "tienda". <br /><br />
+    Este plugin funciona con una tienda Mall y una sola tienda. Todas las transacciones que se realicen usando este
+    método de pago, se autorizarán asociadas al código de comercio tienda. <br></p>
+</div>
+
+
 <table class="form-table">
     <?php $this->generate_settings_html(); ?>
 </table>

--- a/plugin/views/admin/oneclick-admin-options.php
+++ b/plugin/views/admin/oneclick-admin-options.php
@@ -10,7 +10,7 @@ $webpayPlusCommerceCode = $webpayPlus->get_option('webpay_rest_commerce_code');
 <hr>
 
 <div style="clear: both">
-    <a target="_blank" href="https://contrata.transbankdevelopers.cl/?wpcommerce=<?php echo $webpayPlusCommerceCode; ?>&wpenv=<?php echo $webpayPlusEnvironment; ?>&utm_source=woocommerce_plugin&utm_medium=banner&utm_campaign=contrata">
+    <a target="_blank" href="https://contrata.transbankdevelopers.cl/Oneclick/?wpcommerce=<?php echo $webpayPlusCommerceCode; ?>&wpenv=<?php echo $webpayPlusEnvironment; ?>&utm_source=woocommerce_plugin&utm_medium=banner&utm_campaign=contrata">
         <img style="border-radius: 10px; width: 800px; display: block" src="<?php echo plugins_url('/images/oneclick-banner.jpg', dirname(__DIR__)); ?>" alt="">
     </a>
 </div>
@@ -47,4 +47,3 @@ $webpayPlusCommerceCode = $webpayPlus->get_option('webpay_rest_commerce_code');
         </p>
     </div>
 <?php } ?>
-

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -34,7 +34,7 @@ if (!defined('ABSPATH')) {
  * Author: TransbankDevelopers
  * Author URI: https://www.transbank.cl
  * WC requires at least: 3.4.0
- * WC tested up to: 5.1.0
+ * WC tested up to: 5.
  */
 add_action('plugins_loaded', 'woocommerce_transbank_rest_init', 0);
 


### PR DESCRIPTION
Con esta información, podemos ayudar mejor al usuario al momento de querer contratar Oneclick. Podemos saber de manera más simple, si está operando en producción con su propio código de comercio, entonces sabemos que es cliente "stock" y podemos ayudarlo a agilizar su proceso de contratación. 

Al hacer click en el banner de "Contrata acá" llegaría a una URL como esta: 
`https://contrata.transbankdevelopers.cl/?wpcommerce=597035769625&wpenv=TEST&utm_source=woocommerce_plugin&utm_medium=banner&utm_campaign=contrata` 