### PR TITLE
Add guzzle 7 release to github on every release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,5 @@ ehthumbs_vista.db
 
 vendor
 
-transbank-webpay-plus-rest.zip
-transbank-webpay-plus-rest-guzzle7.zip
+transbank-webpay-rest.zip
+transbank-webpay-rest-guzzle7.zip

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ ehthumbs_vista.db
 vendor
 
 transbank-webpay-plus-rest.zip
+transbank-webpay-plus-rest-guzzle7.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,4 @@ deploy:
     on:
       repo: TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest
       tags: true
-      php: 7.3
+      php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,27 @@
 language: php
 php:
   - '7.1'
+  - '7.3'
 script: echo "We don't have tests yet :("
 before_deploy:
   - sh package.sh
 deploy:
   - provider: releases
     name: "$TRAVIS_TAG"
-    file: transbank-webpay-plus-rest.zip
+    file:
+      - transbank-webpay-plus-rest.zip
+      - transbank-webpay-plus-rest-guzzle7.zip
     api_key:
       secure: XHl3tahHkS58bYnIX5SlUdsU9LnecJz8XfQYU99/sPzDmHfW8xmIMsfUQCQjXAtINJhlcghkBRdmchObVgRWVY85S56lqe4TqNfKVkZf5XTqXX0A+2BLPsUN/jUXyN3RzUs9RZVphkTP1ykS6mctWSssRWIPl9SWJxZcyfhi8wQQKc7GadyI9woMnTypNKNGigFdeQOnVlJlNsVC/4cq+r0SAPp28GhoWLmH+2Ek4AbguokM9JcYonwYVCgtlj/F8a9IXKUQv1kb3JIkCklTuKLaWyL6iFI9iTav8WxR26TSDSxE4Eqnv3jzu2aFmM2GercQv+S1MGvJvt+/eyZNU2WWDF5PRZKlikNyaRGqEPICa5Pd8NV6GXxulqJWQlqS2OHwFi1fQXXvlgussuyoTiTO0PcnZFP7xbXsSGblJav6eE2Kd1nban5dc/7osUt+8jv5yQ+M2oYXfzkLowdyBXo/GdHJrCJCrFAdB42UAiHdfHZxzKFqCHagssq5yD6mHFTcIeP+wWBBr5WjUcAKeTbJ2OV3kAX2o7b8pOBP0aXUZLKadW7cvbF9symgNXSugDxRUzkChUOz6B86xyYN9lwQKN4Jr9C+8yTYhcrgLysYsv67GXWdlZ1WORueHvL9h53Yca2lZ+dypc6ecpTr7eLiybxSHVggpg83p7VFHAg=
     skip_cleanup: true
     on:
       repo: TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest
       tags: true
-      php: 7.1
+      php: 7.3
   - provider: script
     skip_cleanup: true
     script: ./scripts/deploy.sh
     on:
       repo: TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest
       tags: true
-      php: 7.1
+      php: 7.3

--- a/package.sh
+++ b/package.sh
@@ -23,8 +23,8 @@ sed -i.bkp "s/Version: VERSION_REPLACE_HERE/Version: ${TRAVIS_TAG#"v"}/g" "$SRC_
 sed -i.bkp "s/VERSION_REPLACE_HERE/${TRAVIS_TAG#"v"}/g" "$SRC_DIR/$README_FILE"
 cp "$SRC_DIR/$COMPOSER_LOCK_FILE" "$SRC_DIR/$COMPOSER_LOCK_FILE.bkp"
 
-PLUGIN_FILE="transbank-webpay-plus-rest.zip"
-PLUGIN_FILE_GUZZLE="transbank-webpay-plus-rest-guzzle7.zip"
+PLUGIN_FILE="transbank-webpay-rest.zip"
+PLUGIN_FILE_GUZZLE="transbank-webpay-rest-guzzle7.zip"
 
 cd $SRC_DIR
 zip -FSr ../$PLUGIN_FILE . -x composer.json composer.lock "$MAIN_FILE.bkp" "$README_FILE.bkp" vendor/tecnickcom/tcpdf/fonts/*

--- a/package.sh
+++ b/package.sh
@@ -11,6 +11,8 @@ fi
 SRC_DIR="plugin"
 MAIN_FILE="webpay-rest.php"
 README_FILE="readme.txt"
+COMPOSER_FILE="composer.json"
+COMPOSER_LOCK_FILE="composer.lock"
 
 
 cd $SRC_DIR
@@ -19,12 +21,27 @@ cd ..
 
 sed -i.bkp "s/Version: VERSION_REPLACE_HERE/Version: ${TRAVIS_TAG#"v"}/g" "$SRC_DIR/$MAIN_FILE"
 sed -i.bkp "s/VERSION_REPLACE_HERE/${TRAVIS_TAG#"v"}/g" "$SRC_DIR/$README_FILE"
+cp "$SRC_DIR/$COMPOSER_LOCK_FILE" "$SRC_DIR/$COMPOSER_LOCK_FILE.bkp"
 
 PLUGIN_FILE="transbank-webpay-plus-rest.zip"
+PLUGIN_FILE_GUZZLE="transbank-webpay-plus-rest-guzzle7.zip"
 
 cd $SRC_DIR
 zip -FSr ../$PLUGIN_FILE . -x composer.json composer.lock "$MAIN_FILE.bkp" "$README_FILE.bkp" vendor/tecnickcom/tcpdf/fonts/*
 zip -ur ../$PLUGIN_FILE ./vendor/tecnickcom/tcpdf/fonts/helvetica.php
+
+# Create Guzzle 7 version
+sed -i.bkp "s/\"php\": \"7.0\"/\"php\": \"7.2.5\"/g" "$COMPOSER_FILE"
+composer require guzzlehttp/guzzle:^7.0
+zip -FSr ../$PLUGIN_FILE_GUZZLE . -x composer.json composer.lock "$MAIN_FILE.bkp" "$README_FILE.bkp" "$COMPOSER_FILE.bkp" vendor/tecnickcom/tcpdf/fonts/*
+zip -ur ../$PLUGIN_FILE_GUZZLE ./vendor/tecnickcom/tcpdf/fonts/helvetica.php
+
+cp "$COMPOSER_LOCK_FILE.bkp" "$COMPOSER_LOCK_FILE"
+rm "$COMPOSER_LOCK_FILE.bkp"
+cp "$COMPOSER_FILE.bkp" "$COMPOSER_FILE"
+rm "$COMPOSER_FILE.bkp"
+composer install
+
 cd ..
 
 cp "$SRC_DIR/$MAIN_FILE.bkp" "$SRC_DIR/$MAIN_FILE"
@@ -34,3 +51,4 @@ rm "$SRC_DIR/$README_FILE.bkp"
 
 echo "Plugin version: $TRAVIS_TAG"
 echo "Plugin file: $PLUGIN_FILE"
+echo "Plugin file Guzzle 7: $PLUGIN_FILE_GUZZLE"


### PR DESCRIPTION
Add another zip with a variation of the plugin that uses Guzzle 7 (requires PHP 7.2+). So if someone has an incompatibility issue can manually install this variation, as recommended on some error messages in the plugin. 