### PR TITLE
Agregando el campo "webpay_rest_description"

### DIFF
--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -226,6 +226,7 @@ function woocommerce_transbank_rest_init()
          **/
         public function init_form_fields()
         {
+			$this->description = $this->get_option('webpay_rest_description');
             $this->form_fields = [
                 'enabled' => [
                     'title'   => __('Activar/Desactivar', 'transbank_webpay_plus_rest'),
@@ -268,7 +269,13 @@ function woocommerce_transbank_rest_init()
                         'completed'  => 'Completed',
                     ],
                     'default' => '',
-                ]
+                ],
+				'webpay_rest_description' => [
+				    'title'       => __('Descripción', 'transbank_webpay_plus_rest'),
+				    'type'        => 'textarea',
+				    'default'     => 'Permite el pago de productos y/o servicios, con tarjetas de crédito, débito y prepago a través de Webpay Plus',
+				    'placeholder' => 'Permite el pago de productos y/o servicios, con tarjetas de crédito, débito y prepago a través de Webpay Plus',
+				],
             ];
         }
 


### PR DESCRIPTION
Agrego el campo "webpay_rest_description" para que los usuarios puedan editar el mensaje de "Permite el pago de productos y/o servicios, con tarjetas de crédito, débito y prepago a través de Webpay Plus" y poner lo que quieran.