### PR TITLE
fix: proper logs location

### DIFF
--- a/plugin/src/Helpers/LogHandler.php
+++ b/plugin/src/Helpers/LogHandler.php
@@ -11,7 +11,6 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-define('Transbank_webpay_Rest_Webpay_ROOT', dirname(dirname(__DIR__)));
 define('Transbank_webpay_Rest_Webpay_UPLOADS', untrailingslashit(wp_upload_dir()['basedir'] . '/transbank_webpay_plus_rest'));
 
 class LogHandler
@@ -28,6 +27,9 @@ class LogHandler
 
     public function __construct($ecommerce = 'woocommerce', $days = 7, $weight = '2MB')
     {
+        // Unique string to avoid anyone outside to guess logs files names
+        $uniqueId = uniqid('', true);
+
         $this->logDir = Transbank_webpay_Rest_Webpay_UPLOADS.'/logs';
         $this->ecommerce = $ecommerce;
         $this->lockfile = $this->logDir.'/set_logs_activate.lock';
@@ -35,7 +37,7 @@ class LogHandler
         $this->confdays = $days;
         $this->confweight = $weight;
         $this->logURL = str_replace($_SERVER['DOCUMENT_ROOT'], '/', $this->logDir);
-        $this->logFile = "{$this->logDir}/log_transbank_{$this->ecommerce}_{$dia}.log";
+        $this->logFile = "{$this->logDir}/log_transbank_{$this->ecommerce}_{$dia}_{$uniqueId}.log";
 
         try {
             if (!file_exists($this->logDir)) {

--- a/plugin/src/Helpers/LogHandler.php
+++ b/plugin/src/Helpers/LogHandler.php
@@ -12,6 +12,7 @@ if (!defined('ABSPATH')) {
 }
 
 define('Transbank_webpay_Rest_Webpay_ROOT', dirname(dirname(__DIR__)));
+define('Transbank_webpay_Rest_Webpay_UPLOADS', untrailingslashit(wp_upload_dir()['basedir'] . '/transbank_webpay_plus_rest'));
 
 class LogHandler
 {
@@ -27,7 +28,7 @@ class LogHandler
 
     public function __construct($ecommerce = 'woocommerce', $days = 7, $weight = '2MB')
     {
-        $this->logDir = Transbank_webpay_Rest_Webpay_ROOT.'/logs';
+        $this->logDir = Transbank_webpay_Rest_Webpay_UPLOADS.'/logs';
         $this->ecommerce = $ecommerce;
         $this->lockfile = $this->logDir.'/set_logs_activate.lock';
         $dia = date('Y-m-d');
@@ -41,7 +42,7 @@ class LogHandler
                 mkdir($this->logDir, 0777, true);
             }
         } catch (Exception $e) {
-            
+
         }
 
         try {
@@ -49,9 +50,9 @@ class LogHandler
                 wp_mkdir_p($this->logDir);
             }
         } catch (Exception $e) {
-            
+
         }
-        
+
         // the default date format is "Y-m-d H:i:s"
         $dateFormat = "Y n j, g:i a";
         // the default output format is "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n"


### PR DESCRIPTION
Fixes https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/issues/118

It will create a new folder transbank_webpay_plus_rest inside the uploads directory, and then will use a logs folder inside it. So logs final path will be: uploads/transbank_webpay_plus_rest/logs/

This way logs will not be lost if the plugin gets upgraded to a new version by any means.

BTW, i think those two defines (Transbank_webpay_Rest_Webpay_ROOT and the new one for the uploads folder) should be inside the main plugin file, webpay-rest.php, to be used in every file if they are needed. As the usual plugins behavior on WP.

Esteban