### PR TITLE
Feat/add services log and error table

### DIFF
--- a/plugin/src/Helpers/DatabaseTableInstaller.php
+++ b/plugin/src/Helpers/DatabaseTableInstaller.php
@@ -4,11 +4,15 @@ namespace Transbank\WooCommerce\WebpayRest\Helpers;
 
 use Transbank\WooCommerce\WebpayRest\Models\Inscription;
 use Transbank\WooCommerce\WebpayRest\Models\Transaction;
+use Transbank\WooCommerce\WebpayRest\Models\TransbankApiServiceLog;
+use Transbank\WooCommerce\WebpayRest\Models\TransbankExecutionErrorLog;
+
+require_once ABSPATH.'wp-admin/includes/upgrade.php';
 
 class DatabaseTableInstaller
 {
     const TABLE_VERSION_OPTION_KEY = 'webpay_orders_table_version';
-    const LATEST_TABLE_VERSION = 5;
+    const LATEST_TABLE_VERSION = 6;
 
     public static function isUpgraded(): bool
     {
@@ -28,99 +32,143 @@ class DatabaseTableInstaller
     public static function createTableTransaction(): bool
     {
         global $wpdb;
-        require_once ABSPATH.'wp-admin/includes/upgrade.php';
-        $charset_collate = $wpdb->get_charset_collate();
+        $charsetCollate = $wpdb->get_charset_collate();
 
         /*
         |--------------------------------------------------------------------------
         | Webpay Transactions Table
         |--------------------------------------------------------------------------
         */
-        $transactionTableName = Transaction::getTableName();
-
-        $sql = "CREATE TABLE `{$transactionTableName}` (
-            `id` bigint(20) NOT NULL AUTO_INCREMENT,
-            `order_id` varchar(60) NOT NULL,
-            `buy_order` varchar(60) NOT NULL,
-            `child_buy_order` varchar(60),
-            `commerce_code` varchar(60),
-            `child_commerce_code` varchar(60),
-            `amount` bigint(20) NOT NULL,
-            `token` varchar(100),
-            `transbank_status` varchar(100),
-            `session_id` varchar(100),
-            `status` varchar(50) NOT NULL,
-            `transbank_response` LONGTEXT,
-            `product` varchar(30),
-            `environment` varchar(20),
-            `error` varchar(255),
-            `detail_error` LONGTEXT,
-            `created_at` TIMESTAMP NOT NULL  DEFAULT NOW(),
+        $tableName = Transaction::getTableName();
+        $sql = "CREATE TABLE `{$tableName}` (
+            `id`                   bigint(20) NOT NULL AUTO_INCREMENT,
+            `order_id`             varchar(60) NOT NULL,
+            `buy_order`            varchar(60) NOT NULL,
+            `child_buy_order`      varchar(60),
+            `commerce_code`        varchar(60),
+            `child_commerce_code`  varchar(60),
+            `amount`               bigint(20) NOT NULL,
+            `token`                varchar(100),
+            `transbank_status`     varchar(100),
+            `session_id`           varchar(100),
+            `status`               varchar(50) NOT NULL,
+            `transbank_response`   LONGTEXT,
+            `last_refund_type`     varchar(100),
+            `last_refund_response` LONGTEXT,
+            `product`              varchar(30),
+            `environment`          varchar(20),
+            `error`                varchar(255),
+            `detail_error`         LONGTEXT,
+            `created_at`           TIMESTAMP NOT NULL  DEFAULT NOW(),
             PRIMARY KEY (id)
-        ) $charset_collate";
+        ) $charsetCollate";
 
         dbDelta($sql);
-
-        $success = empty($wpdb->last_error);
-        if (!$success) {
-            $log = new LogHandler();
-            $log->logError('Error creating transbank tables: '.$transactionTableName);
-            $log->logError($wpdb->last_error);
-
-            add_settings_error('transbank_webpay_orders_table_error', '', 'Transbank Webpay: Error creando tabla webpay_orders: '.$wpdb->last_error, 'error');
-            settings_errors('transbank_webpay_orders_table_error');
-        }
-        return $success;
+        return DatabaseTableInstaller::createTableProccessError($tableName, $wpdb->last_error);
     }
 
     public static function createTableInscription(): bool
     {
         global $wpdb;
-        require_once ABSPATH.'wp-admin/includes/upgrade.php';
-        $charset_collate = $wpdb->get_charset_collate();
+        $charsetCollate = $wpdb->get_charset_collate();
         /*
         |--------------------------------------------------------------------------
         | Oneclick inscriptions table
         |--------------------------------------------------------------------------
         */
-        $inscriptionsTableName = Inscription::getTableName();
-        $sql = "CREATE TABLE `{$inscriptionsTableName}` (
-            `id` bigint(20) NOT NULL AUTO_INCREMENT,
-            `token` varchar(100) NOT NULL,
-            `username` varchar(100),
-            `email` varchar(50) NOT NULL,
-            `user_id` bigint(20),
-            `token_id` bigint(20),
-            `order_id` bigint(20),
+        $tableName = Inscription::getTableName();
+        $sql = "CREATE TABLE `{$tableName}` (
+            `id`                    bigint(20) NOT NULL AUTO_INCREMENT,
+            `token`                 varchar(100) NOT NULL,
+            `username`              varchar(100),
+            `email`                 varchar(50) NOT NULL,
+            `user_id`               bigint(20),
+            `token_id`              bigint(20),
+            `order_id`              bigint(20),
             `pay_after_inscription` TINYINT(1) DEFAULT 0,
-            `finished` TINYINT(1) NOT NULL DEFAULT 0,
-            `response_code` varchar(50),
-            `authorization_code` varchar(50),
-            `card_type` varchar(50),
-            `card_number` varchar(50),
-            `from` varchar(50),
-            `status` varchar(50) NOT NULL,
-            `environment` varchar(20),
-            `commerce_code` varchar(60),
-            `transbank_response` LONGTEXT,
-            `error` varchar(255),
-            `detail_error` LONGTEXT,
-            `created_at` TIMESTAMP NOT NULL  DEFAULT NOW(),
+            `finished`              TINYINT(1) NOT NULL DEFAULT 0,
+            `response_code`         varchar(50),
+            `authorization_code`    varchar(50),
+            `card_type`             varchar(50),
+            `card_number`           varchar(50),
+            `from`                  varchar(50),
+            `status`                varchar(50) NOT NULL,
+            `environment`           varchar(20),
+            `commerce_code`         varchar(60),
+            `transbank_response`    LONGTEXT,
+            `error`                 varchar(255),
+            `detail_error`          LONGTEXT,
+            `created_at`            TIMESTAMP NOT NULL  DEFAULT NOW(),
             PRIMARY KEY (id)
-        ) $charset_collate";
+        ) $charsetCollate";
 
         dbDelta($sql);
+        return DatabaseTableInstaller::createTableProccessError($tableName, $wpdb->last_error);
+    }
 
-        $success = empty($wpdb->last_error);
+    public static function createTableTransbankExecutionErrorLog(): bool
+    {
+        global $wpdb;
+        $charsetCollate = $wpdb->get_charset_collate();
+        $tableName = TransbankExecutionErrorLog::getTableName();
+
+        $sql = "CREATE TABLE `{$tableName}` (
+            `id`               bigint(20) NOT NULL AUTO_INCREMENT,
+            `order_id`         varchar(60) NOT NULL,
+            `service`          varchar(100) NOT NULL,
+            `product`          varchar(30) NOT NULL,
+            `enviroment`       varchar(20) NOT NULL,
+            `commerce_code`    varchar(60) NOT NULL,
+            `data`             LONGTEXT,
+            `error`            varchar(255),
+            `original_error`   LONGTEXT,
+            `custom_error`     LONGTEXT,
+            `created_at`       TIMESTAMP NOT NULL  DEFAULT NOW(),
+            PRIMARY KEY (id)
+        ) $charsetCollate";
+
+        dbDelta($sql);
+        return DatabaseTableInstaller::createTableProccessError($tableName, $wpdb->last_error);
+    }
+
+    public static function createTableTransbankApiServiceLog(): bool
+    {
+        global $wpdb;
+        
+        $charsetCollate = $wpdb->get_charset_collate();
+        $tableName = TransbankApiServiceLog::getTableName();
+
+        $sql = "CREATE TABLE `{$tableName}` (
+            `id`               bigint(20) NOT NULL AUTO_INCREMENT,
+            `order_id`         varchar(60) NOT NULL,
+            `service`          varchar(100) NOT NULL,
+            `product`          varchar(30) NOT NULL,
+            `enviroment`       varchar(20) NOT NULL,
+            `commerce_code`    varchar(60) NOT NULL,
+            `input`            LONGTEXT,
+            `response`         LONGTEXT,
+            `error`            varchar(255),
+            `original_error`   LONGTEXT,
+            `custom_error`     LONGTEXT,
+            `created_at`       TIMESTAMP NOT NULL  DEFAULT NOW(),
+            PRIMARY KEY (id)
+        ) $charsetCollate";
+
+        dbDelta($sql);
+        return DatabaseTableInstaller::createTableProccessError($tableName, $wpdb->last_error);
+    }
+
+    public static function createTableProccessError($tableName, $wpdbError): bool
+    {
+        $success = empty($wpdbError);
         if (!$success) {
             $log = new LogHandler();
-            $log->logError('Error creating transbank tables: '.$inscriptionsTableName);
-            $log->logError($wpdb->last_error);
+            $log->logError('Error creating transbank tables: '.$tableName);
+            $log->logError($wpdbError);
 
-            add_settings_error('transbank_webpay_orders_table_error', '', 'Transbank Webpay: Error creando tabla webpay_orders: '.$wpdb->last_error, 'error');
-            settings_errors('transbank_webpay_orders_table_error');
+            add_settings_error($tableName.'_table_error', '', 'Transbank Webpay: Error creando tabla '.$tableName.': '.$wpdbError, 'error');
+            settings_errors($tableName.'_table_error');
         }
-
         return $success;
     }
 
@@ -128,17 +176,26 @@ class DatabaseTableInstaller
     {
         $successTransaction = static::createTableTransaction();
         $successInscription = static::createTableInscription();
-        if ($successTransaction && $successInscription) {
+        $successExecutionErrorLog = static::createTableTransbankExecutionErrorLog();
+        $successTransbankApiServiceLog = static::createTableTransbankApiServiceLog();
+        if ($successTransaction && $successInscription && $successExecutionErrorLog && $successTransbankApiServiceLog) {
             update_site_option(static::TABLE_VERSION_OPTION_KEY, static::LATEST_TABLE_VERSION);
-        } 
-        return $successTransaction && $successInscription;
+        }
+        return $successTransaction && $successInscription && $successExecutionErrorLog && $successTransbankApiServiceLog;
     }
 
     public static function deleteTable()
     {
+        static::deleteTableByName(Transaction::getTableName());
+        static::deleteTableByName(Inscription::getTableName());
+        static::deleteTableByName(TransbankApiServiceLog::getTableName());
+        static::deleteTableByName(TransbankExecutionErrorLog::getTableName());
+    }
+
+    public static function deleteTableByName($tableName)
+    {
         global $wpdb;
-        $table_name = Transaction::getTableName();
-        $sql = "DROP TABLE IF EXISTS `$table_name`";
+        $sql = "DROP TABLE IF EXISTS `$tableName`";
         $wpdb->query($sql);
         delete_option(static::TABLE_VERSION_OPTION_KEY);
     }

--- a/plugin/src/Models/Inscription.php
+++ b/plugin/src/Models/Inscription.php
@@ -3,6 +3,7 @@
 namespace Transbank\WooCommerce\WebpayRest\Models;
 
 use function is_multisite;
+use Exception;
 use Transbank\WooCommerce\WebpayRest\Exceptions\TokenNotFoundOnDatabaseException;
 
 class Inscription

--- a/plugin/src/Models/Transaction.php
+++ b/plugin/src/Models/Transaction.php
@@ -3,12 +3,14 @@
 namespace Transbank\WooCommerce\WebpayRest\Models;
 
 use function is_multisite;
+use Exception;
 use Transbank\WooCommerce\WebpayRest\Exceptions\TokenNotFoundOnDatabaseException;
 
 class Transaction
 {
     const TRANSACTIONS_TABLE_NAME = 'webpay_rest_transactions';
 
+    const STATUS_PREPARED = 'prepared';
     const STATUS_INITIALIZED = 'initialized';
     const STATUS_FAILED = 'failed';
     const STATUS_ABORTED_BY_USER = 'aborted_by_user';
@@ -121,8 +123,7 @@ class Transaction
             if (!$success) {
                 return array('ok' => false, 'error' => "La tabla '{$transactionTable}' no se encontró en la base de datos.", 'exception' => "{$wpdb->last_error}");
             }
-        }
-        catch(Exception $e) {
+        } catch (Exception $e) {
             return array('ok' => false, 'error' => "La tabla '{$transactionTable}' no se encontró en la base de datos.", 'exception' => "{$e->getMessage()}");
         }
         return array('ok' => true, 'msg' => "La tabla '{$transactionTable}' existe.");

--- a/plugin/src/Models/TransbankApiServiceLog.php
+++ b/plugin/src/Models/TransbankApiServiceLog.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Transbank\WooCommerce\WebpayRest\Models;
+
+class TransbankApiServiceLog
+{
+    const TABLE_NAME = 'transbank_api_service_log';
+
+    /**
+     * @return string
+     */
+    public static function getTableName(): string
+    {
+        global $wpdb;
+        if (is_multisite()) {
+            return $wpdb->base_prefix.static::TABLE_NAME;
+        } else {
+            return $wpdb->prefix.static::TABLE_NAME;
+        }
+    }
+
+    public static function create($orderId, $service, $product, $enviroment, $commerceCode, $input, $response)
+    {
+        global $wpdb;
+
+        return $wpdb->insert(static::getTableName(), [
+            'order_id'         => $orderId,
+            'service'          => $service,
+            'product'          => $product,
+            'enviroment'       => $enviroment,
+            'commerce_code'    => $commerceCode,
+            'input'            => $input,
+            'response'         => $response
+        ]);
+    }
+
+    public static function createError($orderId, $service, $product, $enviroment, $commerceCode, $input, $error, $originalError, $customError)
+    {
+        global $wpdb;
+
+        return $wpdb->insert(static::getTableName(), [
+            'order_id'         => $orderId,
+            'service'          => $service,
+            'product'          => $product,
+            'enviroment'       => $enviroment,
+            'commerce_code'    => $commerceCode,
+            'input'            => $input,
+            'error'            => $error,
+            'original_error'   => $originalError,
+            'custom_error'     => $customError
+        ]);
+    }
+
+}
+

--- a/plugin/src/Models/TransbankExecutionErrorLog.php
+++ b/plugin/src/Models/TransbankExecutionErrorLog.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Transbank\WooCommerce\WebpayRest\Models;
+
+use function is_multisite;
+
+class TransbankExecutionErrorLog
+{
+    const TABLE_NAME = 'transbank_execution_error_log';
+
+    /**
+     * @return string
+     */
+    public static function getTableName(): string
+    {
+        global $wpdb;
+        if (is_multisite()) {
+            return $wpdb->base_prefix.static::TABLE_NAME;
+        } else {
+            return $wpdb->prefix.static::TABLE_NAME;
+        }
+    }
+
+    public static function create($orderId, $service, $product, $enviroment, $commerceCode, $input, $error, $originalError, $customError)
+    {
+        global $wpdb;
+
+        return $wpdb->insert(static::getTableName(), [
+            'order_id'         => $orderId,
+            'service'          => $service,
+            'product'          => $product,
+            'enviroment'       => $enviroment,
+            'commerce_code'    => $commerceCode,
+            'input'            => $input,
+            'error'            => $error,
+            'original_error'   => $originalError,
+            'custom_error'     => $customError
+        ]);
+    }
+
+}


### PR DESCRIPTION
* add 'transbank_api_service_log' table ( to save the invocation of transabank services)
* add 'transbank_execution_error_log' table ( to save execution errors )

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/7391252/df1a9c31-9e3c-439c-8d15-727cf99d63c7)
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/7391252/ef901da3-a2a3-451a-a12c-ca38a7b44201)
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/7391252/90cabebb-0038-40dd-b66e-6029b8e1b960)
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/7391252/ec9cb71c-1a13-4c31-b205-589b5c98c63f)
