### PR TITLE
fix: delete unused function on plugin/js/admin.js

### DIFF
--- a/plugin/js/admin.js
+++ b/plugin/js/admin.js
@@ -1,5 +1,3 @@
-function updateConfig(){
-}
 jQuery(function($) {
   $(".check_conn").on("click",function(e) {
 


### PR DESCRIPTION
-  delete unused function reported by sonarcloud

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/9637b321-5a85-488b-9a96-39e3c59bca3e)

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/763df33f-a111-43ed-8450-542aaafed397)

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/f3ebe5c2-9bff-4269-82c8-830000b15dd0)
