### PR TITLE
Fix: sonarcloud admin views bugs

### DIFF
--- a/plugin/css/tbk.css
+++ b/plugin/css/tbk.css
@@ -288,11 +288,20 @@
     overflow: hidden;
 }
 
+.tbk-plugin-info-container.logs {
+    max-width: 40%;
+}
+
 .info-column-plugin {
     padding: 4px 0px;
     text-align: left;
     word-wrap: break-word;
     border-bottom: dashed 1px #ccc;
+}
+
+.info-column-plugin.log {
+    border-bottom: none;
+    border-top: dashed 1px #ccc;
 }
 
 .tbk_title_legend {

--- a/plugin/css/tbk.css
+++ b/plugin/css/tbk.css
@@ -7,12 +7,10 @@
 .tbk_table_info td {
     width: 300px;
     border-bottom: dashed 1px #ccc;
-    max-width: 50%;
 }
 
 .tbk_table_td {
     width: 200px;
-    max-width: 30%;
 }
 
 .tbk_table_trans pre {
@@ -275,7 +273,6 @@
     background: #eee;
     border-radius: 5px;
     border:solid 1px #999;
-    font-size: 95%;
     text-wrap: unset;
     overflow-wrap: anywhere;
 }
@@ -307,7 +304,7 @@
 .tbk_title_legend {
     color: #1d2327;
     font-size: 1.3em;
-    margin: 1em 0;
+    margin: 16px 0;
     display: block;
     font-weight: 600;
 }

--- a/plugin/css/tbk.css
+++ b/plugin/css/tbk.css
@@ -1,22 +1,22 @@
 
 .tbk_table_info {
-	width: 600px;
-	max-width: 50%;
+    width: 600px;
+    max-width: 50%;
 }
 
 .tbk_table_info td {
-	width: 300px;
+    width: 300px;
     border-bottom: dashed 1px #ccc;
-	max-width: 50%;
+    max-width: 50%;
 }
 
 .tbk_table_td {
-	width: 200px;
-	max-width: 30%;
+    width: 200px;
+    max-width: 30%;
 }
 
 .tbk_table_trans pre {
-	font-size: 12px;
+    font-size: 12px;
 }
 
 .transaction-status-response {
@@ -92,6 +92,15 @@
 
 .label-success {
     background: #5cb85c;
+    border-radius: 5px;
+    padding: 5px;
+    color: #fff;
+    font-weight: bold;
+    font-size: 10px;
+}
+
+.label-danger {
+    background: #ec3206;
     border-radius: 5px;
     padding: 5px;
     color: #fff;
@@ -225,4 +234,71 @@
 
 .tbk-box .woocommerce-save-button.tbk-custom-save-button {
     display: inline-block;
+}
+
+
+.tbk-response-container {
+    display: grid;
+    grid-template-columns: 20px 80px 1fr;
+    grid-gap: 5px;
+    align-items: flex-start;
+    overflow: hidden;
+}
+
+.tbk_response_status {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+}
+
+.tbk-hide {
+    display: none !important;
+}
+.highlight-text {
+    font-weight: bold;
+}
+
+.info-column {
+    padding-top: 5px;
+    padding-bottom: 5px;
+    text-align: left;
+    word-wrap: break-word;
+}
+
+.info-value {
+    text-align:left;
+}
+
+.token pre {
+    margin-top: 0;
+    padding: 5px;
+    background: #eee;
+    border-radius: 5px;
+    border:solid 1px #999;
+    font-size: 95%;
+    text-wrap: unset;
+    overflow-wrap: anywhere;
+}
+
+.tbk-plugin-info-container {
+    display: grid;
+    grid-template-columns: 20px 200px 1fr;
+    grid-gap: 5px;
+    align-items: flex-start;
+    overflow: hidden;
+}
+
+.info-column-plugin {
+    padding: 4px 0px;
+    text-align: left;
+    word-wrap: break-word;
+    border-bottom: dashed 1px #ccc;
+}
+
+.tbk_title_legend {
+    color: #1d2327;
+    font-size: 1.3em;
+    margin: 1em 0;
+    display: block;
+    font-weight: 600;
 }

--- a/plugin/js/admin.js
+++ b/plugin/js/admin.js
@@ -1,117 +1,103 @@
 jQuery(function($) {
-  $(".check_conn").on("click",function(e) {
+    $(".check_conn").on("click",function(e) {
 
-    $(".check_conn").text("Verificando ...");
-    $("#response_title").hide();
-    $("#row_response_status").hide();
-    $("#row_response_url").hide();
-    $("#row_response_token").hide();
-    $("#row_error_message").hide();
-    $("#row_error_detail").hide();
-    $(".tbk_table_trans").empty();
+        $(".check_conn").text("Verificando ...");
 
-    $.post(ajax_object.ajax_url, {action: 'check_connection', nonce: ajax_object.nonce}, function(resp){
-      $(".check_conn").text("Verificar Conexión");
-      $('.tbk-response-title').show();
-      $("#response_title").show();
-      $("#row_response_status").show();
-      $("#row_response_status_text").removeClass("label-success").removeClass("label-danger");
+        $("#tbk_response_status").removeClass("tbk-hide");
+        $("#div_status_ok").addClass("tbk-hide");
+        $("#div_status_error").addClass("tbk-hide");
 
-      if(resp.status.string == "OK") {
-
-        $("#row_response_status_text").addClass("label-success").text("OK").show();
-        $("#row_response_url_text").append(resp.response.url);
-        $("#row_response_token_text").append('<pre>'+resp.response.token+'</pre>');
-
-        $("#row_response_url").show();
-        $("#row_response_token").show();
-
-      } else {
-
-        $("#row_response_status_text").addClass("label-danger").text("ERROR").show();
-        $("#row_error_message_text").append(resp.response.error);
-        $("#row_error_detail_text").append('<code style="display: block; padding: 10px">'+resp.response.detail+'</code>');
-
-        $("#row_error_message").show();
-        $("#row_error_detail").show();
-      }
-
-    })
-
-    e.preventDefault();
-  });
-
-  $('.get-transaction-status').on("click",function(e) {
-      if ($(this).data('sending') === true) {
-          return;
-      }
-      $(this).data('sending', true);
-      $(this).html('Consultando al API REST...');
-     e.preventDefault();
-
-      $.post(ajax_object.ajax_url, {
-          action: 'get_transaction_status',
-          order_id: $(this).data('order-id'),
-          buy_order: $(this).data('buy-order'),
-          token: $(this).data('token'),
-          nonce: window.ajax_object.nonce
-      }, function(response){
-          let $table = $('.transaction-status-response');
-          let statusData = response.status;
-          Object.keys(statusData).forEach(key => {
-              let value = statusData[key] ? statusData[key] : '-';
-              $table.find('.status-' + key).html(value);
-          });
-          $table.find('.status-product').html(response.product);
-
-          let niceJson = JSON.stringify(response.raw, null, 2)
-          $table.find('.status-raw').html(`<pre>${niceJson}</pre>`);
-          $table.show();
-          $(this).data('sending', false);
-          $(this).html('Consultar estado de la transacción');
-
-      }.bind(this))
-      .fail(function(e, a) {
-          $('.error-status-raw').html(`<p>${e.responseJSON.message}</p>`);
-          $('.error-transaction-status-response').show();
-          $(this).data('sending', false);
-          $(this).html('Consultar estado de la transacción');
-      })
-  });
+        $.post(ajax_object.ajax_url, {action: 'check_connection', nonce: ajax_object.nonce}, function(response){
+            $(".check_conn").text("Verificar Conexión");
 
 
-  $(".check_exist_tables").on("click",function(e) {
+            if(response.status.string == "OK") {
+                $("#response_url_text").text(response.response.url);
+                $("#response_token_text").html('<pre>'+response.response.token+'</pre>');
 
-    $(".check_exist_tables").text("Verificando ...");
-    $("#row_tbl_response_status").hide();
-    $("#row_tbl_response_result").hide();
-    $("#row_tbl_error_message").hide();
-    $('.tbk-tbl-response-title').show();
-    $(".tbk_tbl_table_trans").empty();
+                $("#div_status_ok").removeClass("tbk-hide");
 
-    $.post(ajax_object.ajax_url, {action: 'check_exist_tables', nonce: ajax_object.nonce}, function(response){
-      $(".check_exist_tables").text("Verificar Tablas");
-      $("#row_tbl_response_status").show();
-      $("#row_tbl_response_status_text").removeClass("label-success").removeClass("label-danger");
+            } else {
+                $("#error_response_text").text(response.response.error);
+                $("#error_detail_response_text").html('<code style="display: block; padding: 10px">'+response.response.detail+'</code>');
 
-      if(!response.error) {
+                $("#div_status_error").removeClass("tbk-hide");
+            }
 
-        $("#row_tbl_response_status_text").addClass("label-success").text("OK").show();
-        $("#row_tbl_response_result_text").append(response.msg);
+        })
 
-        $("#row_tbl_response_result").show();
+        e.preventDefault();
+    });
 
-      } else {
+    $('.get-transaction-status').on("click",function(e) {
+        if ($(this).data('sending') === true) {
+            return;
+        }
+        $(this).data('sending', true);
+        $(this).html('Consultando al API REST...');
+        e.preventDefault();
 
-        $("#row_tbl_response_status_text").addClass("label-danger").text("ERROR").show();
-        $("#row_tbl_error_message_text").append('<code style="display: block; padding: 10px">' + response.error + ' Exception: ' + response.exception +'</code>');
+        $.post(ajax_object.ajax_url, {
+            action: 'get_transaction_status',
+            order_id: $(this).data('order-id'),
+            buy_order: $(this).data('buy-order'),
+            token: $(this).data('token'),
+            nonce: window.ajax_object.nonce
+        }, function(response){
+            let $table = $('.transaction-status-response');
+            let statusData = response.status;
+            Object.keys(statusData).forEach(key => {
+                let value = statusData[key] ? statusData[key] : '-';
+                $table.find('.status-' + key).html(value);
+            });
+            $table.find('.status-product').html(response.product);
 
-        $("#row_tbl_error_message").show();
-      }
+            let niceJson = JSON.stringify(response.raw, null, 2)
+            $table.find('.status-raw').html(`<pre>${niceJson}</pre>`);
+            $table.show();
+            $(this).data('sending', false);
+            $(this).html('Consultar estado de la transacción');
 
-    })
+        }.bind(this))
+            .fail(function(e, a) {
+                $('.error-status-raw').html(`<p>${e.responseJSON.message}</p>`);
+                $('.error-transaction-status-response').show();
+                $(this).data('sending', false);
+                $(this).html('Consultar estado de la transacción');
+            })
+    });
 
-    e.preventDefault();
-  });
+
+    $(".check_exist_tables").on("click",function(e) {
+        $(".check_exist_tables").text("Verificando ...");
+        $("#tbk-tbl-response-title").removeClass("tbk-hide");
+        $("#div_tables_status").addClass("tbk-hide");
+        $("#div_tables_status_result").addClass("tbk-hide");
+        $("#div_tables_error").addClass("tbk-hide");
+        $("#tbl_response_status_text").removeClass();
+
+        $.post(ajax_object.ajax_url, {action: 'check_exist_tables', nonce: ajax_object.nonce}, function(response){
+            $(".check_exist_tables").text("Verificar Tablas");
+            $("#div_tables_status").removeClass("tbk-hide");
+
+            if(!response.error) {
+
+                $("#tbl_response_status_text").addClass("label-success").text("OK").show();
+                $("#tbl_response_result_text").text(response.msg);
+
+                $("#div_tables_status_result").removeClass("tbk-hide");
+
+            } else {
+
+                $("#tbl_response_status_text").addClass("label-danger").text("ERROR").show();
+                $("#tbl_error_message_text").html('<code style="display: block; padding: 10px">' + response.error + ' Exception: ' + response.exception +'</code>');
+
+                $("#div_tables_error").removeClass("tbk-hide");
+            }
+
+        })
+
+        e.preventDefault();
+    });
 
 })

--- a/plugin/views/admin/admin-options.php
+++ b/plugin/views/admin/admin-options.php
@@ -30,7 +30,7 @@ if ($environment === \Transbank\Webpay\Options::ENVIRONMENT_INTEGRATION) { ?>
 <?php } ?>
 
 <div class="tbk-box">
-    <table class="form-table">
+    <table class="form-table" role="presentation">
         <?php $this->generate_settings_html(); ?>
     </table>
     <button name="save" class="button-primary woocommerce-save-button tbk-custom-save-button" type="submit" value="<?php _e('Guardar cambios', 'transbank_wc_plugin'); ?>"><?php _e('Guardar cambios', 'transbank_wc_plugin'); ?></button>

--- a/plugin/views/admin/healthcheck.php
+++ b/plugin/views/admin/healthcheck.php
@@ -15,53 +15,51 @@ if (!defined('ABSPATH')) {
                 <li>Si arroja algún error debes volver a verificar.</li>
                 <li>Si los errores persisten puedes obtener más información en el tab de "registros (logs)".</li>
             </ul>
-        </div>  
-        <table class="table table-striped">
-            <tbody>
-            <tr>
-                <td>
-                    <button class="check_exist_tables button">Verificar Tablas</button>
-                </td>
-            </tr>
-            </tbody>
-        </table>
+        </div>
+        <div>
+            <button class="check_exist_tables button">Verificar Tablas</button>
+        </div>
         <hr>
-        <h4 class="tbk-tbl-response-title" style="display: none">Respuesta</h4>
-        <table class="table table-borderless">
-            <tbody>
-            <tr id="row_tbl_response_status" style="display:none">
-                <td>
-                    <div
-                        title="Informa el estado de la verificación de la existencia de las tablas de plugin"
-                        class="label label-info">?
-                    </div>
-                    <strong>Estado: </strong>
-                </td>
-                <td>
-                                    <span id="row_tbl_response_status_text" class="label tbk_tbl_table_trans"
-                                          style="display:none"></span>
-                </td>
-            </tr>
-            <tr id="row_tbl_response_result" style="display:none">
-                <td>
-                    <div title="Resultado de la verificación"
-                         class="label label-info">?
-                    </div>
-                    <strong>Resultado: </strong>
-                </td>
-                <td id="row_tbl_response_result_text" class="tbk_tbl_table_trans"></td>
-            </tr>
-            <tr id="row_tbl_error_message" style="display:none">
-                <td>
-                    <div title="Mensaje de error devuelto por la verificación y Wordpress"
-                         class="label label-info">?
-                    </div>
-                    <strong>Error: </strong>
-                </td>
-                <td id="row_tbl_error_message_text" class="tbk_tbl_table_trans"></td>
-            </tr>
-            </tbody>
-        </table>
+        <h4 id="tbk-tbl-response-title" class="tbk-hide">Respuesta</h4>
+        <div class="tbk-response-container tbk-hide" id="div_tables_status">
+            <div class="info-column">
+                <div title="Informa el estado de la verificación de la existencia de las tablas de plugin"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column">
+                <span class="highlight-text"> Estado: </span>
+            </div>
+            <div class="info-column">
+                <span class="label" id="tbl_response_status_text"></span>
+            </div>
+        </div>
+        <div class="tbk-response-container tbk-hide" id="div_tables_status_result">
+            <div class="info-column">
+                <div title="Resultado de la verificación de tablas"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column">
+                <span class="highlight-text"> Resultado: </span>
+            </div>
+            <div class="info-column">
+                <span class="label" id="tbl_response_result_text"></span>
+            </div>
+        </div>
+        <div class="tbk-response-container tbk-hide" id="div_tables_error">
+            <div class="info-column">
+                <div title="Error en la verificación de existencia de tablas"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column">
+                <span class="highlight-text"> Error: </span>
+            </div>
+            <div class="info-column">
+                <span class="label" id="tbl_error_message_text"></span>
+            </div>
+        </div>
     </div>
 
     <div class="transbank_rest_tool">
@@ -69,170 +67,202 @@ if (!defined('ABSPATH')) {
         <p>Esta herramienta permite probar tu configuración (ambiente, código de comercio y llave secreta (Api Key
             Secret). Al verificar conexión se envía una solicitud para crear una transacción de prueba.
             Si ocurre algún problema, puedes obtener más información en el tab de "registros (logs)"</p>
-        <table class="table table-striped">
-            <tbody>
-            <tr>
-                <td>
-                    <button class="check_conn button">Verificar Conexión</button>
-                </td>
-            </tr>
-            </tbody>
-        </table>
+        <div>
+            <button class="check_conn button">Verificar Conexión</button>
+        </div>
         <hr>
-        <h4 class="tbk-response-title" style="display: none">Respuesta de Transbank</h4>
-        <table class="table table-borderless">
-            <tbody>
-            <tr id="row_response_status" style="display:none">
-                <td>
-                    <div
-                        title="Informa el estado de la comunicación con Transbank mediante método create_transaction"
-                        class="label label-info">?
+        <div class="tbk-response-status tbk-hide" id="tbk_response_status">
+            <h4 id="response_title">Respuesta de Transbank</h4>
+            <div class="tbk-status-ok tbk-hide" id="div_status_ok">
+                <div class="tbk-response-container" id="div_status">
+                    <div class="info-column">
+                        <div title="Informa el estado de la comunicación con Transbank mediante método create_transaction"
+                             class="label label-info">?
+                        </div>
                     </div>
-                    <strong>Estado: </strong>
-                </td>
-                <td>
-                                    <span id="row_response_status_text" class="label tbk_table_trans"
-                                          style="display:none"></span>
-                </td>
-            </tr>
-            <tr id="row_response_url" style="display:none">
-                <td>
-                    <div title="URL entregada por Transbank para realizar la transacción"
-                         class="label label-info">?
+                    <div class="info-column">
+                        <span class="highlight-text"> Estado: </span>
                     </div>
-                    <strong>URL: </strong>
-                </td>
-                <td id="row_response_url_text" class="tbk_table_trans"></td>
-            </tr>
-            <tr id="row_response_token" style="display:none">
-                <td>
-                    <div title="Token entregada por Transbank para realizar la transacción"
-                         class="label label-info">?
+                    <div class="info-column">
+                        <span class="label label-success" id="response_status_text">OK</span>
                     </div>
-                    <strong>Token: </strong>
-                </td>
-                <td id="row_response_token_text" class="tbk_table_trans"></td>
-            </tr>
-            <tr id="row_error_message" style="display:none">
-                <td>
-                    <div title="Mensaje de error devuelto por Transbank al fallar init_transaction"
-                         class="label label-info">?
+                </div>
+                <div class="tbk-response-container" id="div_response_url">
+                    <div class="info-column">
+                        <div title="URL entregada por Transbank para realizar la transacción"
+                             class="label label-info">?
+                        </div>
                     </div>
-                    <strong>Error: </strong>
-                </td>
-                <td id="row_error_message_text" class="tbk_table_trans"></td>
-            </tr>
-            <tr id="row_error_detail" style="display:none">
-                <td>
-                    <div title="Detalle del error devuelto por Transbank al fallar init_transaction"
-                         class="label label-info">?
+                    <div class="info-column">
+                        <span class="highlight-text"> URL: </span>
                     </div>
-                    <strong>Detalle: </strong>
-                </td>
-                <td id="row_error_detail_text" class="tbk_table_trans"></td>
-            </tr>
-            </tbody>
-        </table>
+                    <div class="info-column" id="response_url_text">
+                    </div>
+                </div>
+                <div class="tbk-response-container" id="div_response_token">
+                    <div class="info-column">
+                        <div title="Token entregada por Transbank para realizar la transacción"
+                             class="label label-info">?
+                        </div>
+                    </div>
+                    <div class="info-column">
+                        <span class="highlight-text"> Token: </span>
+                    </div>
+                    <div class="info-column token" id="response_token_text">
+                    </div>
+                </div>
+            </div>
+            <div class="tbk-status-error tbk-hide" id="div_status_error">
+                <div class="tbk-response-container" id="div_error_status">
+                    <div class="info-column">
+                        <div title="Status devuelto por Transbank al fallar create_transaction"
+                             class="label label-info">?
+                        </div>
+                    </div>
+                    <div class="info-column">
+                        <span class="highlight-text"> Estado: </span>
+                    </div>
+                    <div class="info-column" id="error_response_status">
+                        <span class="label label-danger" id="error_response_status_text">ERROR</span>
+                    </div>
+                </div>
+                <div class="tbk-response-container" id="div_error_message">
+                    <div class="info-column">
+                        <div title="Mensaje de error devuelto por Transbank al fallar create_transaction"
+                             class="label label-info">?
+                        </div>
+                    </div>
+                    <div class="info-column">
+                        <span class="highlight-text"> Error: </span>
+                    </div>
+                    <div class="info-column" id="error_response_text">
+                    </div>
+                </div>
+                <div class="tbk-response-container" id="div_error_detail">
+                    <div class="info-column">
+                        <div title="Detalle del error devuelto por Transbank al fallar create_transaction"
+                             class="label label-info">?
+                        </div>
+                    </div>
+                    <div class="info-column">
+                        <span class="highlight-text"> Detalle: </span>
+                    </div>
+                    <div class="info-column" id="error_detail_response_text">
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
-    <div class="tbk-box">
-
+    <div class="transbank_rest_tool">
         <h3 class="tbk_title_h3">Información de Plugin / Ambiente</h3>
-        <table class="tbk_table_info">
-            <tr>
-                <td>
-                    <div title="Nombre del E-commerce instalado en el servidor"
-                         class="label label-info">?
-                    </div>
-                    <strong>Software E-commerce: </strong>
-                </td>
-                <td class="tbk_table_td">
+        <div class="tbk-plugin-info-container">
+            <div class="info-column-plugin">
+                <div title="Nombre del E-commerce instalado en el servidor"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column-plugin">
+                <span class="highlight-text"> Software E-commerce: </span>
+            </div>
+            <div class="info-column-plugin">
+                <span class="label" id="software_ecommerce">
                     <?php echo $datos_hc->server_resume->plugin_info->ecommerce; ?>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <div
-                        title="Versión de <?php echo $datos_hc->server_resume->plugin_info->ecommerce; ?> instalada en el servidor"
-                        class="label label-info">?
-                    </div>
-                    <strong>Version E-commerce: </strong>
-                </td>
-                <td class="tbk_table_td">
+                </span>
+            </div>
+            <div class="info-column-plugin">
+                <div title="Versión de <?php echo $datos_hc->server_resume->plugin_info->ecommerce; ?> instalada en el servidor"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column-plugin">
+                <span class="highlight-text"> Version E-commerce: </span>
+            </div>
+            <div class="info-column-plugin">
+                <span class="label" id="version_ecommerce">
                     <?php echo $datos_hc->server_resume->plugin_info->ecommerce_version; ?>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <div
-                        title="Versión del plugin Webpay para <?php echo $datos_hc->server_resume->plugin_info->ecommerce; ?> instalada actualmente"
-                        class="label label-info">?
-                    </div>
-                    <strong>Versión actual del plugin: </strong>
-                </td>
-                <td class="tbk_table_td">
+                </span>
+            </div>
+            <div class="info-column-plugin">
+                <div title="Versión del plugin Webpay para <?php echo $datos_hc->server_resume->plugin_info->ecommerce; ?> instalada actualmente"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column-plugin">
+                <span class="highlight-text"> Versión actual del plugin: </span>
+            </div>
+            <div class="info-column-plugin">
+                <span class="label" id="current_version_plugin">
                     <?php echo $datos_hc->server_resume->plugin_info->current_plugin_version; ?>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <div
-                        title="Última versión del plugin Webpay para <?php echo $datos_hc->server_resume->plugin_info->ecommerce; ?> disponible"
-                        class="label label-info">?
-                    </div>
-                    <strong>Última versión del plugin: </strong>
-                </td>
-                <td class="tbk_table_td"
-                ><?php echo $datos_hc->server_resume->plugin_info->last_plugin_version; ?>
-                </td>
-            </tr>
-        </table>
-        <br>
+                </span>
+            </div>
+            <div class="info-column-plugin">
+                <div title="Última versión del plugin Webpay para <?php echo $datos_hc->server_resume->plugin_info->ecommerce; ?> disponible"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column-plugin">
+                <span class="highlight-text"> Última versión del plugin: </span>
+            </div>
+            <div class="info-column-plugin">
+                <span class="label" id="last_version_available">
+                    <?php echo $datos_hc->server_resume->plugin_info->last_plugin_version; ?>
+                </span>
+            </div>
+        </div>
+        <hr>
         <h3 class="tbk_title_h3">Estado de la Extensiones de PHP</h3>
         <h4 class="tbk_table_title">Información Principal</h4>
-        <table class="tbk_table_info">
-            <tr>
-                <td>
-                    <div title="Descripción del Servidor Web instalado" class="label label-info">?</div>
-                    <strong>Software Servidor: </strong>
-                </td>
-                <td class="tbk_table_td">
+        <div class="tbk-plugin-info-container">
+            <div class="info-column-plugin">
+                <div title="Descripción del Servidor Web instalado"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column-plugin">
+                <span class="highlight-text"> Software Servidor: </span>
+            </div>
+            <div class="info-column-plugin">
+                <span class="label" id="software_server">
                     <?php echo $datos_hc->server_resume->server_version->server_software; ?>
-                </td>
-            </tr>
-        </table>
-        <h4 class="tbk_table_title">PHP</h4>
-        <table class="tbk_table_info">
-            <tr>
-                <td>
-                    <div
-                        title="Informa si la versión de PHP instalada en el servidor es compatible con el plugin de Webpay"
-                        class="label label-info">?
-                    </div>
-                    <strong>Estado de PHP</strong>
-                </td>
-                <td class="tbk_table_td"><span class="label
-                                                <?php if ($datos_hc->server_resume->php_version->status == 'OK') {
-    echo 'label-success';
-} else {
-    echo 'label-danger';
-} ?>">
-                                                <?php echo $datos_hc->server_resume->php_version->status; ?>
-                                                </span>
-                </td>
-            </tr>
-            <tr>
-                <td>
-                    <div title="Versión de PHP instalada en el servidor" class="label label-info">?
-                    </div>
-                    <strong>Versión: </strong></td>
-                <td class="tbk_table_td">
+                </span>
+            </div>
+            <div class="info-column-plugin">
+                <div title="Informa si la versión de PHP instalada en el servidor es compatible con el plugin de Webpay"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column-plugin">
+                <span class="highlight-text"> Estado de PHP: </span>
+            </div>
+            <div class="info-column-plugin">
+                <span class="label
+                   <?php if ($datos_hc->server_resume->php_version->status == 'OK') {
+                    echo 'label-success';
+                } else {
+                    echo 'label-danger';
+                } ?>"><?php echo $datos_hc->server_resume->php_version->status; ?>
+                </span>
+            </div>
+            <div class="info-column-plugin">
+                <div title="Versión de PHP instalada en el servidor"
+                     class="label label-info">?
+                </div>
+            </div>
+            <div class="info-column-plugin">
+                <span class="highlight-text"> Versión: </span>
+            </div>
+            <div class="info-column-plugin">
+                <span class="label" id="php_version">
                     <?php echo $datos_hc->server_resume->php_version->version; ?>
-                </td>
-            </tr>
-        </table>
+                </span>
+            </div>
+
+        </div>
+        <hr>
         <h4 class="tbk_table_title">Extensiones PHP requeridas</h4>
         <table class="tbk_table_info">
+            <caption style="display: none">Tabla con el resumen de las extensiones de PHP requeridas</caption>
             <tr>
                 <th>Extensión</th>
                 <th>Estado</th>
@@ -241,14 +271,14 @@ if (!defined('ABSPATH')) {
             <tr>
                 <td style="font-weight:bold">json</td>
                 <td>
-                                                <span class="label
-                                                <?php if ($datos_hc->php_extensions_status->json->status == 'OK') {
-    echo 'label-success';
-} else {
-    echo 'label-danger';
-} ?>">
-                                                <?php echo $datos_hc->php_extensions_status->json->status; ?>
-                                                </span>
+                        <span class="label
+                            <?php if ($datos_hc->php_extensions_status->json->status == 'OK') {
+                            echo 'label-success';
+                        } else {
+                            echo 'label-danger';
+                        } ?>">
+                            <?php echo $datos_hc->php_extensions_status->json->status; ?>
+                        </span>
                 </td>
                 <td class="tbk_table_td">
                     <?php echo $datos_hc->php_extensions_status->json->version; ?>
@@ -257,14 +287,14 @@ if (!defined('ABSPATH')) {
             <tr>
                 <td style="font-weight:bold">dom</td>
                 <td>
-                                                <span class="label
-                                                <?php if ($datos_hc->php_extensions_status->dom->status == 'OK') {
-    echo 'label-success';
-} else {
-    echo 'label-danger';
-} ?>">
-                                                <?php echo $datos_hc->php_extensions_status->dom->status; ?>
-                                                </span>
+                        <span class="label
+                            <?php if ($datos_hc->php_extensions_status->dom->status == 'OK') {
+                            echo 'label-success';
+                        } else {
+                            echo 'label-danger';
+                        } ?>">
+                            <?php echo $datos_hc->php_extensions_status->dom->status; ?>
+                        </span>
                 </td>
                 <td class="tbk_table_td">
                     <?php echo $datos_hc->php_extensions_status->dom->version; ?>
@@ -273,21 +303,20 @@ if (!defined('ABSPATH')) {
             <tr>
                 <td style="font-weight:bold">curl</td>
                 <td>
-                                                <span class="label
-                                                <?php if ($datos_hc->php_extensions_status->curl->status == 'OK') {
-    echo 'label-success';
-} else {
-    echo 'label-danger';
-} ?>">
-                                                <?php echo $datos_hc->php_extensions_status->curl->status; ?>
-                                                </span>
+                        <span class="label
+                        <?php if ($datos_hc->php_extensions_status->curl->status == 'OK') {
+                            echo 'label-success';
+                        } else {
+                            echo 'label-danger';
+                        } ?>">
+                            <?php echo $datos_hc->php_extensions_status->curl->status; ?>
+                        </span>
                 </td>
                 <td class="tbk_table_td">
                     <?php echo $datos_hc->php_extensions_status->curl->version; ?>
                 </td>
             </tr>
         </table>
-        <br>
     </div>
 
 

--- a/plugin/views/admin/logs.php
+++ b/plugin/views/admin/logs.php
@@ -5,111 +5,136 @@ if (!defined('ABSPATH')) {
 ?>
 <div class="tbk-box">
     <div id="logs" class="tab-pane">
-        <fieldset>
+        <h3 class="tbk_title_h3">Información de Registros</h3>
+        <div id="tbk_information_logs" style="margin-bottom: 30px;">
+            <div class="tbk-plugin-info-container logs" id="div_status_logs">
+                <div class="info-column">
+                    <div title="Informa si actualmente se guarda la información de cada compra mediante Webpay"
+                         class="label label-info">?
+                    </div>
+                </div>
+                <div class="info-column">
+                    <span class="highlight-text"> Estado de Registros:  </span>
+                </div>
+                <div class="info-column">
+                    <span id="action_txt" class="label label-success">Registro activado</span>
+                </div>
+            </div>
+            <div class="tbk-plugin-info-container logs" id="div_logs_path" >
+                <div class="info-column">
+                    <div title="Carpeta en el servidor en donde se guardan los archivos con la informacón de cada compra mediante Webpay"
+                         class="label label-info">?
+                    </div>
+                </div>
+                <div class="info-column-plugin log">
+                    <span class="highlight-text"> Directorio de registros:  </span>
+                </div>
+                <div class="info-column-plugin log">
+                <span class="label">
+                    <?php echo json_decode($log->getResume(), true)['log_dir']; ?>
+                </span>
+                </div>
+            </div>
+            <div class="tbk-plugin-info-container logs" id="div_logs_number">
+                <div class="info-column">
+                    <div title="Cantidad de archivos que guardan la información de cada compra mediante Webpay"
+                         class="label label-info">?
+                    </div>
+                </div>
+                <div class="info-column-plugin log">
+                    <span class="highlight-text"> Cantidad de Registros en Directorio:  </span>
+                </div>
+                <div class="info-column-plugin log">
+                <span class="label">
+                   <?php echo json_decode($log->getResume(), true)['logs_count']['log_count']; ?>
+                </span>
+                </div>
+            </div>
+            <div class="tbk-plugin-info-container logs" id="div_logs_list">
+                <div class="info-column">
+                    <div title="Lista los archivos archivos que guardan la información de cada compra mediante Webpay"
+                         class="label label-info">?
+                    </div>
+                </div>
+                <div class="info-column-plugin log">
+                    <span class="highlight-text"> Listado de Registros Disponibles:  </span>
+                </div>
+                <div class="info-column-plugin log">
+                <span class="label">
+                   <?php
+                   $logs_list = isset(json_decode(
+                           $log->getResume(),
+                           true
+                       )['logs_list']) ? json_decode(
+                       $log->getResume(),
+                       true
+                   )['logs_list'] : [];
+                   foreach ($logs_list as $index) {
+                       echo '<li>'.$index.'</li>';
+                   }
+                   ?>
+                </span>
+                </div>
+            </div>
+        </div>
 
-            <h3 class="tbk_title_h3">Información de Registros</h3>
-            <table class="tbk_table_info">
-                <tr style="display: none; visibility: hidden">
-                    <td>
-                        <div
-                            title="Informa si actualmente se guarda la información de cada compra mediante Webpay"
-                            class="label label-info">?
-                        </div>
-                        <strong>Estado de Registros: </strong></td>
-                    <td class="tbk_table_td"><span id="action_txt"
-                                                   class="label label-success">Registro activado</span><br>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <div
-                            title="Carpeta en el servidor en donde se guardan los archivos con la informacón de cada compra mediante Webpay"
-                            class="label label-info">?
-                        </div>
-                        <strong>Directorio de registros: </strong></td>
-                    <td class="tbk_table_td">
-                        <?php echo json_decode($log->getResume(), true)['log_dir']; ?>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <div
-                            title="Cantidad de archivos que guardan la información de cada compra mediante Webpay"
-                            class="label label-info">?
-                        </div>
-                        <strong>Cantidad de Registros en Directorio: </strong></td>
-                    <td class="tbk_table_td">
-                        <?php echo json_decode($log->getResume(), true)['logs_count']['log_count']; ?>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <div
-                            title="Lista los archivos archivos que guardan la información de cada compra mediante Webpay"
-                            class="label label-info">?
-                        </div>
-                        <strong>Listado de Registros Disponibles: </strong></td>
-                    <td class="tbk_table_td">
-                        <ul style="font-size:0.8em;list-style: disc">
-                            <?php
-                            $logs_list = isset(json_decode(
-    $log->getResume(),
-    true
-)['logs_list']) ? json_decode(
-    $log->getResume(),
-    true
-)['logs_list'] : [];
-                            foreach ($logs_list as $index) {
-                                echo '<li>'.$index.'</li>';
-                            }
-                            ?>
-                        </ul>
-                    </td>
-                </tr>
-            </table>
-            <?php
 
-            $lastLog = json_decode($log->getLastLog(), true); ?>
-            <h3 class="tbk_title_h3">Últimos Registros</h3>
-            <table class="tbk_table_info">
-                <tr>
-                    <td>
-                        <div title="Nombre del útimo archivo de registro creado"
-                             class="label label-info">?
-                        </div>
-                        <strong>Último Documento: </strong></td>
-                    <td class="tbk_table_td">
-                        <?php echo $lastLog['log_file'] ?? '-'; ?>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <div title="Peso del último archivo de registro creado"
-                             class="label label-info">?
-                        </div>
-                        <strong>Peso del Documento: </strong></td>
-                    <td class="tbk_table_td">
-                        <?php echo $lastLog['log_size'] ?? '-'; ?>
-                    </td>
-                </tr>
-                <tr>
-                    <td>
-                        <div title="Cantidad de líneas que posee el último archivo de registro creado"
-                             class="label label-info">?
-                        </div>
-                        <strong>Cantidad de Líneas: </strong></td>
-                    <td class="tbk_table_td">
-                        <?php echo $lastLog['log_regs_lines'] ?? '-'; ?>
-                    </td>
-                </tr>
-            </table>
-            <br>
-            <pre>
-                        <span
-                            style="font-size: 10px; padding: 10px; font-family:monospace; display: block; background: white;width: fit-content;">
-    <?php echo $lastLog['log_content'] ?? '-'; ?>
+        <h3 class="tbk_title_h3">Últimos Registros</h3>
+        <?php $lastLog = json_decode($log->getLastLog(), true); ?>
+        <div id="tbk-last-logs" >
+            <div class="tbk-plugin-info-container logs" id="div_last_log">
+                <div class="info-column">
+                    <div title="Nombre del útimo archivo de registro creado"
+                         class="label label-info">?
+                    </div>
+                </div>
+                <div class="info-column-plugin">
+                    <span class="highlight-text"> Último Documento: </span>
+                </div>
+                <div class="info-column-plugin">
+                        <span class="label">
+                            <?php echo $lastLog['log_file'] ?? '-'; ?>
                         </span>
-                    </pre>
-        </fieldset>
+                </div>
+            </div>
+            <div class="tbk-plugin-info-container logs" id="div_size_log">
+                <div class="info-column">
+                    <div title="Peso del último archivo de registro creado"
+                         class="label label-info">?
+                    </div>
+                </div>
+                <div class="info-column-plugin">
+                    <span class="highlight-text"> Peso del Documento: </span>
+                </div>
+                <div class="info-column-plugin">
+                        <span class="label">
+                            <?php echo $lastLog['log_size'] ?? '-'; ?>
+                        </span>
+                </div>
+            </div>
+            <div class="tbk-plugin-info-container logs" id="div_lines_logs">
+                <div class="info-column">
+                    <div title="Cantidad de líneas que posee el último archivo de registro creado"
+                         class="label label-info">?
+                    </div>
+                </div>
+                <div class="info-column-plugin">
+                    <span class="highlight-text"> Cantidad de Líneas: </span>
+                </div>
+                <div class="info-column-plugin">
+                        <span class="label">
+                            <?php echo $lastLog['log_regs_lines'] ?? '-'; ?>
+                        </span>
+                </div>
+            </div>
+        </div>
+
+        <div id="tbk_last_log_content">
+            <pre>
+            <span style="font-size: 10px; padding: 5px; font-family:monospace; display: block; background: white;">
+                <?php echo $lastLog['log_content'] ?? '-'; ?>
+            </span>
+        </pre>
+        </div>
     </div>
 </div>

--- a/plugin/views/admin/oneclick-admin-options.php
+++ b/plugin/views/admin/oneclick-admin-options.php
@@ -41,7 +41,7 @@ $trackinfo = PluginInfoHelper::getInfo();
 </div>
 
 <div class="tbk-box">
-    <table class="form-table">
+    <table class="form-table" role="presentation">
         <?php $this->generate_settings_html(); ?>
     </table>
     <button name="save" class="button-primary woocommerce-save-button tbk-custom-save-button" type="submit" value="<?php _e('Guardar cambios', 'transbank_wc_plugin'); ?>"><?php _e('Guardar cambios', 'transbank_wc_plugin'); ?></button>
@@ -85,7 +85,7 @@ if ($environment === \Transbank\Webpay\Options::ENVIRONMENT_INTEGRATION) { ?>
     <p>Encuentra más detalles y funcionalidades en la <a target="_blank" href="http://transbankdevelopers.cl/plugin/woocommerce/" rel="noopener">documentación oficial del plugin</a></p>
 
     <h3>Conoce las novedades</h3>
-    <iframe width="100%" height="315" src="https://www.youtube.com/embed/aVElZf5xqKQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <iframe title="Video que muestra las novedades del plugin" width="100%" height="315" src="https://www.youtube.com/embed/aVElZf5xqKQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 </div>
 

--- a/plugin/views/admin/phpinfo.php
+++ b/plugin/views/admin/phpinfo.php
@@ -7,7 +7,7 @@ if (!defined('ABSPATH')) {
 <div class="tbk-box">
     <div id="php_info" class="tab-pane">
         <fieldset class="tbk_info">
-            <h3 class="tbk_title_h3">Informe PHP info</h3>
+            <legend class="tbk_title_legend">Informe PHP info</legend>
             <a class="button-primary" href="<?php echo admin_url('admin-ajax.php'); ?>?action=show_php_info_report" target="_blank" rel="noopener">
                 Mostrar PHP Info en Html
             </a>


### PR DESCRIPTION
This PR resolves several sonar cloud bugs associated with the use of tables.

- [x] Replace tables by grid on Healthcheck

Success:

https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/af5d2e44-723e-4e9d-86ad-e7d88d5741cf

Error:

https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/3bb87834-6d22-44d5-a7ae-c326420640e7

- [x] Replace tables logs
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/bff6c992-d106-400b-9510-c98694be6bae)

- [x] Replace h3 by legend on php.info
- [x] Add attribute rol on admin-options table and oneclick-admin table

