### PR TITLE
fix: replace require by require_once 

### DIFF
--- a/plugin/src/Controllers/ThankYouPageController.php
+++ b/plugin/src/Controllers/ThankYouPageController.php
@@ -49,12 +49,12 @@ class ThankYouPageController
             $dateAccepted->setTimeZone(new DateTimeZone(wc_timezone_string()));
             $paymentType = ResponseController::getHumanReadablePaymentType($firstTransaction->paymentTypeCode);
             $installmentType = ResponseController::getHumanReadableInstallemntsType($firstTransaction->paymentTypeCode);
-            require __DIR__.'/../../views/order-summary-oneclick.php';
+            require_once __DIR__.'/../../views/order-summary-oneclick.php';
 
             return;
         }
         $data = (new ResponseController([]))->getTransactionDetails($finalResponse);
         list($authorizationCode, $amount, $sharesNumber, $transactionResponse, $installmentType, $date_accepted, $sharesAmount, $paymentType) = $data;
-        require __DIR__.'/../../views/order-summary.php';
+        require_once __DIR__.'/../../views/order-summary.php';
     }
 }

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -85,9 +85,9 @@ function woocommerce_transbank_rest_init()
         return;
     }
 
-    require __DIR__.'/src/Tokenization/WC_Payment_Token_Oneclick.php';
+    require_once __DIR__.'/src/Tokenization/WC_Payment_Token_Oneclick.php';
 
-    
+
 
     /**
      * Añadir Transbank Plus a Woocommerce.


### PR DESCRIPTION
This PR resolve a require bug reported by sonarcloud.

- [x] replace require by require_once on ThanYouPageController.php and webpay_rest.php

Test:

- [x] Checkout with Oneclick mall

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/4fa3fbe0-39bc-4d85-8764-c1e99f6a401e)


 