### PR TITLE
fix: add aria-describedby attribute to order summary tables

### DIFF
--- a/plugin/views/order-summary-oneclick.php
+++ b/plugin/views/order-summary-oneclick.php
@@ -4,8 +4,8 @@ if (!defined('ABSPATH')) {
 }
 ?>
 <br />
-<h2>Detalles del pago</h2>
-<table class="shop_table order_details">
+<h2 id="payment_details">Detalles del pago</h2>
+<table class="shop_table order_details" aria-describedby="payment_details">
     <tfoot>
     <tr>
         <th scope="row">Respuesta de la Transacción:</th>

--- a/plugin/views/order-summary.php
+++ b/plugin/views/order-summary.php
@@ -4,8 +4,8 @@ if (!defined('ABSPATH')) {
 }
 ?>
 <br />
-<h2>Detalles del pago</h2>
-<table class="shop_table order_details">
+<h2 id="payment_details">Detalles del pago</h2>
+<table class="shop_table order_details" aria-describedby="payment_details">
     <tfoot>
     <tr>
         <th scope="row">Respuesta de la Transacción:</th>


### PR DESCRIPTION
This PR resolve sonarcloud bugs associated to orders summary tables on checkout customer view.

- [x] Summary Webpay plus  
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/072e6bd2-0fd6-4d3c-a577-aaa7b7f28788)

- [x] Summary Oneclick Mall
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/176ed4b5-942b-46d5-8e80-118ee60c8aa7)
