### PR TITLE
fix: show get_status view when transaction was made with oneclick 

### DIFF
--- a/plugin/js/admin.js
+++ b/plugin/js/admin.js
@@ -45,6 +45,12 @@ jQuery(function($) {
         }, function(response){
             let $table = $('.transaction-status-response');
             let statusData = response.status;
+            if(response.product == "webpay_plus"){
+                $("#tbk_wpp_vci").removeClass("tbk-hide");
+                $("#tbk_wpp_session_id").removeClass("tbk-hide");
+            }else{
+                $("#tbk_wpoc_commerce_code").removeClass("tbk-hide");
+            }
             Object.keys(statusData).forEach(key => {
                 let value = statusData[key] ? statusData[key] : '-';
                 $table.find('.status-' + key).html(value);

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -20,7 +20,7 @@ class TransactionStatusController
         }
 
         $orderId = filter_input(INPUT_POST, 'order_id', FILTER_SANITIZE_NUMBER_INT);
-        $buyOrder = filter_input(INPUT_POST, 'buy_order', FILTER_SANITIZE_NUMBER_INT);
+        $buyOrder = filter_input(INPUT_POST, 'buy_order', FILTER_SANITIZE_STRING);
         $token = filter_input(INPUT_POST, 'token', FILTER_SANITIZE_STRING);
 
         $transaction = Transaction::getApprovedByOrderId($orderId);
@@ -42,7 +42,7 @@ class TransactionStatusController
             $firstDetail = json_decode(json_encode($status->getDetails()[0]), true);
 
             $response = array_merge($statusArray, $firstDetail);
-            unset($response['detail']);
+            unset($response['details']);
             wp_send_json([
                 'product' => $transaction->product,
                 'status'  => $response,

--- a/plugin/views/get-status.php
+++ b/plugin/views/get-status.php
@@ -56,7 +56,7 @@ if (!$transaction) {
         <dt>Código de comercio:</dt>
         <dd class="status-commerceCode"></dd>
     </dl>
-    <dl class="transaction-status-response" id="tbk_wpp_session_id">
+    <dl class="transaction-status-response tbk-hide" id="tbk_wpp_session_id">
         <dt>ID Sesión:</dt>
         <dd class="status-sessionId"></dd>
     </dl>

--- a/plugin/views/get-status.php
+++ b/plugin/views/get-status.php
@@ -17,7 +17,7 @@ if (!$transaction) {
 
 <div class="transaction-status-response" id="transaction_status_admin" style="display: none">
     <dl class="transaction-status-response">
-        <dt>Producto</dt>
+        <dt>Producto:</dt>
         <dd class="status-product"></dd>
     </dl>
     <dl class="transaction-status-response">
@@ -44,7 +44,7 @@ if (!$transaction) {
         <dt>Código de autorización:</dt>
         <dd class="status-authorizationCode"></dd>
     </dl>
-    <dl class="transaction-status-response">
+    <dl class="transaction-status-response tbk-hide" id="tbk_wpp_vci">
         <dt>VCI:</dt>
         <dd class="status-vci"></dd>
     </dl>
@@ -52,7 +52,11 @@ if (!$transaction) {
         <dt>Orden de compra:</dt>
         <dd class="status-buyOrder"></dd>
     </dl>
-    <dl class="transaction-status-response">
+    <dl class="transaction-status-response tbk-hide" id="tbk_wpoc_commerce_code">
+        <dt>Código de comercio:</dt>
+        <dd class="status-commerceCode"></dd>
+    </dl>
+    <dl class="transaction-status-response" id="tbk_wpp_session_id">
         <dt>ID Sesión:</dt>
         <dd class="status-sessionId"></dd>
     </dl>


### PR DESCRIPTION
This PR resolve an issue in get_status view when transaction was made with oneclick.

Changelog:

- [x] Replace FILTER_SANITIZE_NUMBER_INT by FILTER_SANITIZE_STRING to buy_order in TransactionStatusController
- [x] Hide vci and session_id fields when transaction was made with oneclick

https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16402208/00847961-1aa2-4cab-a3d0-36bf47094da9


