### PR TITLE
fix: undefined variable $webpayPlusCommerceCode

### DIFF
--- a/plugin/views/admin/components/info-validacion-webpay-oneclick-box.php
+++ b/plugin/views/admin/components/info-validacion-webpay-oneclick-box.php
@@ -3,7 +3,7 @@
     Para operar en el ambiente productivo, con dinero real, debes tener tu <strong>código de comercio Mall</strong>, <strong>código de comercio Tienda</strong> y tu <strong>Api Key (llave secreta)</strong>.
 
     <h4>Código de comercio</h4>
-    Si no lo tienes, puedes solicitarlo en <a target="_blank" href="https://contrata.transbankdevelopers.cl/Oneclick/?wpcommerce=<?php echo $webpayPlusCommerceCode; ?>&wpenv=<?php echo $webpayPlusEnvironment; ?>&utm_source=woocommerce_plugin&utm_medium=banner&utm_campaign=contrata">usando este formulario</a>.
+    Si no lo tienes, puedes solicitarlo en <a target="_blank" href="https://contrata.transbankdevelopers.cl/Oneclick/?wpcommerce=<?php echo empty($webpayPlusCommerceCode) ? '' : $webpayPlusCommerceCode; ?>&wpenv=<?php echo empty($webpayPlusEnvironment) ? '' : $webpayPlusEnvironment; ?>&utm_source=woocommerce_plugin&utm_medium=banner&utm_campaign=contrata">usando este formulario</a>.
 
     <h4>Tu Api Key: Proceso de validación</h4>
     Si ya tienes tus códigos de comercio, lo único que te faltaría es tu Api Key. Para obtenerla, debes completar el siguiente formulario:


### PR DESCRIPTION
This PR resolve the PHP warning messages due to undefined variable `$webpayPlusCommerceCode` (fix #169) by checking whether `$webpayPlusCommerceCode` and `$webpayPlusEnvironment` exist before printing into the link anchor.