### PR TITLE
feat: add hpos compatibility

### DIFF
--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -7,6 +7,7 @@ use DateTimeZone;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 use Transbank\WooCommerce\WebpayRest\Models\Transaction;
 use Transbank\WooCommerce\WebpayRest\Helpers\InteractsWithFullLog;
+use Transbank\WooCommerce\WebpayRest\Helpers\HposHelper;
 use Transbank\Plugin\Exceptions\Webpay\TimeoutWebpayException;
 use Transbank\Plugin\Exceptions\Webpay\UserCancelWebpayException;
 use Transbank\Plugin\Exceptions\Webpay\DoubleTokenWebpayException;
@@ -182,17 +183,19 @@ class ResponseController
         list($authorizationCode, $amount, $sharesNumber, $transactionResponse, $paymentCodeResult, $date_accepted, $sharesAmount, $paymentType) = $this->getTransactionDetails($result);
         $cardNumber = $result->cardDetail['card_number'];
         $date = $date_accepted->format('d-m-Y / H:i:s');
-        update_post_meta($wooCommerceOrder->get_id(), 'transactionResponse', $transactionResponse);
-        update_post_meta($wooCommerceOrder->get_id(), 'buyOrder', $result->buyOrder);
-        update_post_meta($wooCommerceOrder->get_id(), 'authorizationCode', $authorizationCode);
-        update_post_meta($wooCommerceOrder->get_id(), 'cardNumber', $cardNumber);
-        update_post_meta($wooCommerceOrder->get_id(), 'paymentCodeResult', $paymentCodeResult);
-        update_post_meta($wooCommerceOrder->get_id(), 'amount', $amount);
-        update_post_meta($wooCommerceOrder->get_id(), 'installmentsNumber', $sharesNumber ? $sharesNumber : '0');
-        update_post_meta($wooCommerceOrder->get_id(), 'installmentsAmount', $sharesAmount ? $sharesAmount : '0');
-        update_post_meta($wooCommerceOrder->get_id(), 'transactionDate', $date);
-        update_post_meta($wooCommerceOrder->get_id(), 'webpay_transaction_id', $webpayTransaction->id);
-        update_post_meta($wooCommerceOrder->get_id(), 'webpay_rest_response', json_encode($result));
+        $hPosHelper = new HposHelper();
+
+        $hPosHelper->updateMeta($wooCommerceOrder, 'transactionResponse', $transactionResponse);
+        $hPosHelper->updateMeta($wooCommerceOrder, 'buyOrder', $result->buyOrder);
+        $hPosHelper->updateMeta($wooCommerceOrder, 'authorizationCode', $authorizationCode);
+        $hPosHelper->updateMeta($wooCommerceOrder, 'cardNumber', $cardNumber);
+        $hPosHelper->updateMeta($wooCommerceOrder, 'paymentCodeResult', $paymentCodeResult);
+        $hPosHelper->updateMeta($wooCommerceOrder, 'amount', $amount);
+        $hPosHelper->updateMeta($wooCommerceOrder, 'installmentsNumber', $sharesNumber ? $sharesNumber : '0');
+        $hPosHelper->updateMeta($wooCommerceOrder, 'installmentsAmount', $sharesAmount ? $sharesAmount : '0');
+        $hPosHelper->updateMeta($wooCommerceOrder, 'transactionDate', $date);
+        $hPosHelper->updateMeta($wooCommerceOrder, 'webpay_transaction_id', $webpayTransaction->id);
+        $hPosHelper->updateMeta($wooCommerceOrder, 'transactionResponse', json_encode($result));
 
         $message = 'Pago exitoso con Webpay Plus';
 

--- a/plugin/src/Helpers/HposHelper.php
+++ b/plugin/src/Helpers/HposHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Transbank\WooCommerce\WebpayRest\Helpers;
+use WC_Order;
+
+class HposHelper
+{
+ private $isHposAvailable;
+ private const WC_VERSION_SINCE_HPOS = '8.2';
+ private $wooCommerceVersion;
+
+ public function __construct()
+ {
+    $this->wooCommerceVersion = get_option('woocommerce_version');
+    $this->isHposAvailable = $this->checkIfHposExists();
+ }
+ public function checkIfHposExists()
+ {
+   return version_compare( $this->wooCommerceVersion, HposHelper::WC_VERSION_SINCE_HPOS, '>=');
+}
+
+ public function updateMeta(WC_Order $wooCommerceOrder, $key, $value){
+   if($this->isHposAvailable) {
+      $wooCommerceOrder->update_meta_data($key, $value);
+   }
+   else {
+      update_post_meta($wooCommerceOrder->get_id(), $key, $value);
+   }
+ }
+
+}

--- a/plugin/src/Helpers/HposHelper.php
+++ b/plugin/src/Helpers/HposHelper.php
@@ -5,27 +5,28 @@ use WC_Order;
 
 class HposHelper
 {
- private $isHposAvailable;
- private const WC_VERSION_SINCE_HPOS = '8.2';
- private $wooCommerceVersion;
+    private $isHposAvailable;
+    private const WC_VERSION_SINCE_HPOS = '8.2';
+    private $wooCommerceVersion;
 
- public function __construct()
- {
-    $this->wooCommerceVersion = get_option('woocommerce_version');
-    $this->isHposAvailable = $this->checkIfHposExists();
- }
- public function checkIfHposExists()
- {
-   return version_compare( $this->wooCommerceVersion, HposHelper::WC_VERSION_SINCE_HPOS, '>=');
-}
+    public function __construct()
+    {
+        $this->wooCommerceVersion = get_option('woocommerce_version');
+        $this->isHposAvailable = $this->checkIfHposExists();
+    }
+    public function checkIfHposExists()
+    {
+        return version_compare( $this->wooCommerceVersion, HposHelper::WC_VERSION_SINCE_HPOS, '>=');
+    }
 
- public function updateMeta(WC_Order $wooCommerceOrder, $key, $value){
-   if($this->isHposAvailable) {
-      $wooCommerceOrder->update_meta_data($key, $value);
-   }
-   else {
-      update_post_meta($wooCommerceOrder->get_id(), $key, $value);
-   }
- }
+    public function updateMeta(WC_Order $wooCommerceOrder, $key, $value)
+    {
+        if($this->isHposAvailable) {
+            $wooCommerceOrder->update_meta_data($key, $value);
+        }
+        else {
+            update_post_meta($wooCommerceOrder->get_id(), $key, $value);
+        }
+    }
 
 }

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -2,6 +2,7 @@
 use Transbank\WooCommerce\WebpayRest\Controllers\TransactionStatusController;
 use Transbank\WooCommerce\WebpayRest\Helpers\DatabaseTableInstaller;
 use Transbank\WooCommerce\WebpayRest\Helpers\SessionMessageHelper;
+use Transbank\WooCommerce\WebpayRest\Helpers\HposHelper;
 use Transbank\WooCommerce\WebpayRest\Models\Transaction;
 use Transbank\WooCommerce\WebpayRest\PaymentGateways\WC_Gateway_Transbank_Oneclick_Mall_REST;
 use Transbank\WooCommerce\WebpayRest\PaymentGateways\WC_Gateway_Transbank_Webpay_Plus_REST;
@@ -59,6 +60,19 @@ add_action('admin_enqueue_scripts', function () {
 });
 
 add_filter('plugin_action_links_'.plugin_basename(__FILE__), 'transbank_webpay_rest_add_rest_action_links');
+
+
+$hposHelper = new HposHelper();
+$hPosExists = $hposHelper->checkIfHposExists();
+if ($hPosExists)
+{
+    add_action('before_woocommerce_init', function () {
+        if (class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
+            \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+        }
+    });
+}
+
 
 //Start sessions if not already done
 add_action('init', function () {

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -68,7 +68,10 @@ if ($hPosExists)
 {
     add_action('before_woocommerce_init', function () {
         if (class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
-            \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('custom_order_tables', __FILE__, true);
+            \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
+                'custom_order_tables',
+                __FILE__,
+                true);
         }
     });
 }
@@ -164,14 +167,24 @@ register_uninstall_hook(__FILE__, 'transbank_rest_remove_database');
 if ($hPosExists)
 {
     add_action('add_meta_boxes', function () {
-        $screen = wc_get_container()->get(Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class)->custom_orders_table_usage_is_enabled()
+        $screen = wc_get_container()
+            ->get(Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class)
+            ->custom_orders_table_usage_is_enabled()
             ? wc_get_page_screen_id('shop-order')
             : 'shop_order';
-        add_meta_box('transbank_check_payment_status', __('Verificar estado del pago', 'transbank_wc_plugin'), function ($post_or_order_object) {
-            $order = ($post_or_order_object instanceof WP_Post) ? wc_get_order($post_or_order_object->ID) : $post_or_order_object;
-            $transaction = Transaction::getApprovedByOrderId($order->get_id());
-            include_once __DIR__.'/views/get-status.php';
-        }, $screen, 'side', 'core');
+        add_meta_box(
+            'transbank_check_payment_status',
+            __('Verificar estado del pago', 'transbank_wc_plugin'),
+            function ($post_or_order_object) {
+                $order = ($post_or_order_object instanceof WP_Post)
+                ? wc_get_order($post_or_order_object->ID)
+                : $post_or_order_object;
+                $transaction = Transaction::getApprovedByOrderId($order->get_id());
+                include_once __DIR__.'/views/get-status.php';
+            },
+            $screen,
+            'side',
+            'core');
     });
 }
 else


### PR DESCRIPTION
Add compatibility for hpos since woocommerce 8.2 version. For previous versions it maintains older methods.
Orders data is now stored by woocommerce on tables 
_wc_orders
_wc_order_addresses
_wc_order_operational_data
_wc_orders_meta

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/101830551/43928a30-c5b8-47df-a243-bc8bde124ffe)

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/101830551/f9860ae9-94e6-4642-b079-947928ae05ba)

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/101830551/a04d235d-223b-4549-a886-a07a46c26182)

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/101830551/fef7627a-6620-4dbf-8687-ab1d99d8da7b)

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/101830551/165ca34a-8598-4226-bc97-706aa23e08b8)
