### PR TITLE
fix: webpay timeout response

### DIFF
--- a/plugin/src/Models/Transaction.php
+++ b/plugin/src/Models/Transaction.php
@@ -85,13 +85,13 @@ class Transaction
         global $wpdb;
         $transactionTableName = Transaction::getTableName();
         $sql = $wpdb->prepare(
-            "SELECT * FROM $transactionTableName WHERE session_id = '%s' && order_id='%s'",
+            "SELECT * FROM $transactionTableName WHERE session_id = '%s' && buy_order='%s'",
             $sessionId,
             $buyOrder
         );
         $sqlResult = $wpdb->get_results($sql);
         if (!is_array($sqlResult) || count($sqlResult) <= 0) {
-            throw new TokenNotFoundOnDatabaseException('No se encontró el session_id y order_id en la base de datos de transacciones, por lo que no se puede completar el proceso');
+            throw new TokenNotFoundOnDatabaseException('No se encontró el session_id y buy_order en la base de datos de transacciones, por lo que no se puede completar el proceso');
         }
 
         return $sqlResult[0];


### PR DESCRIPTION
This PR fix the flow when the answer for a Webpay Plus transaction is form timeout.

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/101830551/0b1e7200-1e77-4c79-9814-785aa2984f43)
