### PR TITLE
refactor: remove hire section on oneclick settings on woocommerce panel

### DIFF
--- a/plugin/views/admin/oneclick-admin-options.php
+++ b/plugin/views/admin/oneclick-admin-options.php
@@ -15,15 +15,6 @@ $trackinfo = PluginInfoHelper::getInfo();
 </style>
 
 <div class="" style="display: flex; flex-wrap: wrap; margin-bottom: 10px">
-    <div style="flex: 1; margin-bottom: 10px">
-        <div style="margin-right: 10px; height: 100%; background: #fff; border-radius: 10px;">
-            <a target="_blank" href="https://contrata-oneclick.continuumhq.dev/Oneclick">
-                <img style="border-radius: 10px; width: 400px; margin-right: 10px; display: block" src="<?php echo plugins_url('/images/oneclick-banner.jpg', dirname(__DIR__)); ?>" alt="">
-            </a>
-        </div>
-    </div>
-
-
     <div style="flex: 1; margin-bottom: 10px; margin-right: 10px;  background: #fff; border-radius: 10px; padding: 20px; display:inline-block">
         <h3 style="margin-top: 0">Webpay Oneclick Mall</h3>
         <p>Webpay Oneclick le permite a tus usuarios inscribir su tarjeta en su cuenta de usuario dentro de tu sitio, para que luego puedan


### PR DESCRIPTION
This PR removes the section to hire the service:

Before:
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16856300/176bec89-fefb-4001-adba-3011362f567d)

After:
![Captura de pantalla 2024-01-18 a las 5 03 53 p m](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/16856300/bf4c8ae6-e2e7-4a36-9a6f-eaf1f8451ed7)
