### PR TITLE
fix:warnings in transaction view

### DIFF
--- a/plugin/src/Helpers/WebpayTransactionsTable.php
+++ b/plugin/src/Helpers/WebpayTransactionsTable.php
@@ -72,7 +72,7 @@ class WebpayTransactionsTable extends WP_List_Table
             !is_numeric($_GET['paged']) ||
             $_GET['paged'] <= 0) ? 1 :  esc_sql($_GET['paged']);
 
-        $perPage = 5;
+        $perPage = 20;
         $offset = ($paged - 1) * $perPage;
 
         $totalItemsQuery = 'SELECT COUNT(*) FROM '.Transaction::getTableName();

--- a/plugin/src/Helpers/WebpayTransactionsTable.php
+++ b/plugin/src/Helpers/WebpayTransactionsTable.php
@@ -65,9 +65,6 @@ class WebpayTransactionsTable extends WP_List_Table
         global $wpdb, $_wp_column_headers;
         $screen = get_current_screen();
 
-        $totalItemsQuery = 'SELECT COUNT(*) FROM '.Transaction::getTableName();
-        $itemsQuery = 'SELECT * FROM '.Transaction::getTableName().' ORDER BY %i %i LIMIT %d, %d';
-
         $orderby = isset($_GET['orderby']) ? sanitize_sql_orderby($_GET['orderby']) : 'ID';
         $order = isset($_GET['order']) ? sanitize_sql_orderby($_GET['order']) : 'DESC';
 
@@ -78,12 +75,15 @@ class WebpayTransactionsTable extends WP_List_Table
         $perPage = 5;
         $offset = ($paged - 1) * $perPage;
 
+        $totalItemsQuery = 'SELECT COUNT(*) FROM '.Transaction::getTableName();
+        $itemsQuery = 'SELECT * FROM '.Transaction::getTableName().' ORDER BY %i '.$order.' LIMIT %d, %d';
+
         $totalItems = $wpdb->get_var($totalItemsQuery);
         $totalPages = ceil($totalItems / $perPage);
 
         $this->items = $wpdb->get_results($wpdb->prepare(
             $itemsQuery,
-            [$orderby, $order, (int)$offset, (int)$perPage]
+            [$orderby, (int)$offset, (int)$perPage]
         ));
 
         $this->set_pagination_args([

--- a/plugin/src/Helpers/WebpayTransactionsTable.php
+++ b/plugin/src/Helpers/WebpayTransactionsTable.php
@@ -17,9 +17,9 @@ class WebpayTransactionsTable extends WP_List_Table
     public function __construct()
     {
         parent::__construct([
-            'singular' => 'transbank_transaction', //Singular label
-            'plural'   => 'transbank_transactions', //plural label, also this well be one of the table css class
-            'ajax'     => false, //We won't support Ajax for this table
+            'singular' => 'transbank_transaction',
+            'plural'   => 'transbank_transactions',
+            'ajax'     => false,
         ]);
     }
 
@@ -65,46 +65,41 @@ class WebpayTransactionsTable extends WP_List_Table
         global $wpdb, $_wp_column_headers;
         $screen = get_current_screen();
 
-        /* -- Preparing your query -- */
         $query = 'SELECT * FROM '.Transaction::getTableName();
 
-        /* -- Ordering parameters -- */
-        //Parameters that are going to be used to order the result
         $orderby = isset($_GET['orderby']) ? sanitize_sql_orderby($_GET['orderby']) : 'ID';
         $order = isset($_GET['order']) ? sanitize_sql_orderby($_GET['order']) : 'DESC';
         $query .= ' ORDER BY %s %s';
-        /* -- Pagination parameters -- */
-        //Number of elements in your table?
+
         $totalitems = $wpdb->query($wpdb->prepare(
             $query,
             [$orderby, $order]
-        )); //return the total number of affected rows
-        //How many to display per page?
+        ));
+
         $perpage = 20;
-        //Which page is this?
+
         $paged = !empty($_GET['paged']) ? esc_sql($_GET['paged']) : '';
-        //Page Number
+
         if (empty($paged) || !is_numeric($paged) || $paged <= 0) {
             $paged = 1;
-        } //How many pages do we have in total?
-        $totalpages = ceil($totalitems / $perpage); //adjust the query to take pagination into account
+        }
+        $totalpages = ceil($totalitems / $perpage);
+
         if (!empty($paged) && !empty($perpage)) {
             $offset = ($paged - 1) * $perpage;
             $query .= ' LIMIT %d, %d';
-        } /* -- Register the pagination -- */
+        }
+
         $this->set_pagination_args([
             'total_items' => $totalitems,
             'total_pages' => $totalpages,
             'per_page'    => $perpage,
         ]);
-        //The pagination links are automatically built according to those parameters
 
-        /* -- Register the Columns -- */
         $columns = $this->get_columns();
         $_wp_column_headers[$screen->id] = $columns;
         $this->_column_headers = [$columns, [], $this->get_sortable_columns(), 'id'];
 
-        /* -- Fetch the items -- */
         $this->items = $wpdb->get_results($wpdb->prepare(
             $query,
             [$orderby, $order, (int)$offset, (int)$perpage]

--- a/plugin/src/Helpers/WebpayTransactionsTable.php
+++ b/plugin/src/Helpers/WebpayTransactionsTable.php
@@ -71,29 +71,29 @@ class WebpayTransactionsTable extends WP_List_Table
         $order = isset($_GET['order']) ? sanitize_sql_orderby($_GET['order']) : 'DESC';
         $query .= ' ORDER BY %s %s';
 
-        $totalitems = $wpdb->query($wpdb->prepare(
+        $totalItems = $wpdb->query($wpdb->prepare(
             $query,
             [$orderby, $order]
         ));
 
-        $perpage = 20;
+        $perPage = 20;
 
         $paged = !empty($_GET['paged']) ? esc_sql($_GET['paged']) : '';
 
         if (empty($paged) || !is_numeric($paged) || $paged <= 0) {
             $paged = 1;
         }
-        $totalpages = ceil($totalitems / $perpage);
+        $totalPages = ceil($totalItems / $perPage);
 
-        if (!empty($paged) && !empty($perpage)) {
-            $offset = ($paged - 1) * $perpage;
+        if (!empty($paged) && !empty($perPage)) {
+            $offset = ($paged - 1) * $perPage;
             $query .= ' LIMIT %d, %d';
         }
 
         $this->set_pagination_args([
-            'total_items' => $totalitems,
-            'total_pages' => $totalpages,
-            'per_page'    => $perpage,
+            'total_items' => $totalItems,
+            'total_pages' => $totalPages,
+            'per_page'    => $perPage,
         ]);
 
         $columns = $this->get_columns();
@@ -102,7 +102,7 @@ class WebpayTransactionsTable extends WP_List_Table
 
         $this->items = $wpdb->get_results($wpdb->prepare(
             $query,
-            [$orderby, $order, (int)$offset, (int)$perpage]
+            [$orderby, $order, (int)$offset, (int)$perPage]
         ));
     }
 

--- a/plugin/src/Helpers/WebpayTransactionsTable.php
+++ b/plugin/src/Helpers/WebpayTransactionsTable.php
@@ -72,10 +72,13 @@ class WebpayTransactionsTable extends WP_List_Table
         //Parameters that are going to be used to order the result
         $orderby = isset($_GET['orderby']) ? sanitize_sql_orderby($_GET['orderby']) : 'ID';
         $order = isset($_GET['order']) ? sanitize_sql_orderby($_GET['order']) : 'DESC';
-        $query .= ' ORDER BY '.$orderby.' '.$order;
+        $query .= ' ORDER BY %s %s';
         /* -- Pagination parameters -- */
         //Number of elements in your table?
-        $totalitems = $wpdb->query($wpdb->prepare($query)); //return the total number of affected rows
+        $totalitems = $wpdb->query($wpdb->prepare(
+            $query,
+            [$orderby, $order]
+        )); //return the total number of affected rows
         //How many to display per page?
         $perpage = 20;
         //Which page is this?
@@ -87,7 +90,7 @@ class WebpayTransactionsTable extends WP_List_Table
         $totalpages = ceil($totalitems / $perpage); //adjust the query to take pagination into account
         if (!empty($paged) && !empty($perpage)) {
             $offset = ($paged - 1) * $perpage;
-            $query .= ' LIMIT '.(int) $offset.','.(int) $perpage;
+            $query .= ' LIMIT %d, %d';
         } /* -- Register the pagination -- */
         $this->set_pagination_args([
             'total_items' => $totalitems,
@@ -102,7 +105,10 @@ class WebpayTransactionsTable extends WP_List_Table
         $this->_column_headers = [$columns, [], $this->get_sortable_columns(), 'id'];
 
         /* -- Fetch the items -- */
-        $this->items = $wpdb->get_results($wpdb->prepare($query));
+        $this->items = $wpdb->get_results($wpdb->prepare(
+            $query,
+            [$orderby, $order, (int)$offset, (int)$perpage]
+        ));
     }
 
     public function column_amount($item)


### PR DESCRIPTION
This PR resolve warning in transaction view.

before:
![Captura de pantalla 2024-01-19 a la(s) 13 24 07](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/77408943-6352-46a3-8d44-169cbeb8d9da)

after:
<img width="2399" alt="image" src="https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/37c6bc06-7631-4a77-865c-c20d02357cb9">
