### PR TITLE
fix: warning in response controller

### DIFF
--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -31,6 +31,11 @@ class ResponseController
     protected $webpayplusTransbankSdk;
 
     /**
+     * @var InteractsWithFullLog
+     */
+    private $interactsWithFullLog;
+
+    /**
      * ResponseController constructor.
      *
      * @param array $pluginConfig

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -225,7 +225,7 @@ class ResponseController
             $wooCommerceOrder
         );
 
-        $this->interactsWithFullLog->logWebpayPlusGuardandoCommitExitoso($token_ws); // Logs
+        $this->interactsWithFullLog->logWebpayPlusGuardandoCommitExitoso($result->buyOrder);
 
         $this->setAfterPaymentOrderStatus($wooCommerceOrder);
     }

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -52,7 +52,7 @@ class ResponseController
      *
      * @return string
      */
-    public static function getHumanReadableInstallemntsType($paymentTypeCode): string
+    public static function getHumanReadableInstallmentsType($paymentTypeCode): string
     {
         $installmentTypes = [
             'VD' => 'Venta Débito',
@@ -293,7 +293,7 @@ class ResponseController
         } else {
             $transactionResponse = 'Transacción Rechazada';
         }
-        $paymentCodeResult = self::getHumanReadableInstallemntsType($paymentTypeCode);
+        $paymentCodeResult = self::getHumanReadableInstallmentsType($paymentTypeCode);
 
         $paymentType = $this->getHumanReadablePaymentType($paymentTypeCode);
 

--- a/plugin/src/Controllers/ThankYouPageController.php
+++ b/plugin/src/Controllers/ThankYouPageController.php
@@ -48,7 +48,7 @@ class ThankYouPageController
             $dateAccepted = new DateTime($finalResponse->transactionDate ?? null, new DateTimeZone('UTC'));
             $dateAccepted->setTimeZone(new DateTimeZone(wc_timezone_string()));
             $paymentType = ResponseController::getHumanReadablePaymentType($firstTransaction->paymentTypeCode);
-            $installmentType = ResponseController::getHumanReadableInstallemntsType($firstTransaction->paymentTypeCode);
+            $installmentType = ResponseController::getHumanReadableInstallmentsType($firstTransaction->paymentTypeCode);
             require_once __DIR__.'/../../views/order-summary-oneclick.php';
 
             return;

--- a/plugin/src/Helpers/InteractsWithFullLog.php
+++ b/plugin/src/Helpers/InteractsWithFullLog.php
@@ -2,9 +2,15 @@
 
 namespace Transbank\WooCommerce\WebpayRest\Helpers;
 
+use Transbank\Plugin\Helpers\PluginLogger;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkFactory;
- 
+
 class InteractsWithFullLog {
+
+    /**
+    * @var PluginLogger
+    */
+    private $log;
 
     public function __construct()
     {

--- a/plugin/src/Helpers/InteractsWithFullLog.php
+++ b/plugin/src/Helpers/InteractsWithFullLog.php
@@ -140,8 +140,8 @@ class InteractsWithFullLog {
         }
     }
 
-    public function logWebpayPlusGuardandoCommitExitoso($token){
-        $this->log->logInfo('C.5. Transacción con commit exitoso en Transbank y guardado => token: '.$token);
+    public function logWebpayPlusGuardandoCommitExitoso($buyOrder){
+        $this->log->logInfo('C.5. Transacción con commit exitoso en Transbank y guardado => OC: '.$buyOrder);
     }
 
     public function logWebpayPlusGuardandoCommitError($token, $result){


### PR DESCRIPTION
Fixed warning in response controller when order is complete successfully

Before:

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/22b82308-fc8d-4520-81c2-51a13147ee2b)

Test:
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/61082f7c-7875-40b7-a103-938a848d0a02)
