### PR TITLE
fix: plugin webhooks

### DIFF
--- a/plugin/src/Controllers/OneclickInscriptionResponseController.php
+++ b/plugin/src/Controllers/OneclickInscriptionResponseController.php
@@ -69,7 +69,10 @@ class OneclickInscriptionResponseController
             $finishInscriptionResponse = $resp['finishInscriptionResponse'];
             $order = $this->getWcOrder($inscription->order_id);
             $from = $inscription->from;
-            do_action('transbank_oneclick_inscription_finished', $order, $from);
+            do_action('wc_transbank_oneclick_inscription_finished', [
+                'order' => $order,
+                'from' => $from
+            ]);
 
             // Todo: guardar la información del usuario al momento de crear la inscripción y luego obtenerla en base al token,
             // por si se pierde la sesión
@@ -92,7 +95,11 @@ class OneclickInscriptionResponseController
             // Set this token as the users new default token
             WC_Payment_Tokens::set_users_default(get_current_user_id(), $token->get_id());
 
-            do_action('transbank_oneclick_inscription_approved', $finishInscriptionResponse, $token, $from);
+            do_action('wc_transbank_oneclick_inscription_approved', [
+                'transbankInscriptionResponse' => $finishInscriptionResponse,
+                'transbankToken' => $token,
+                'from' =>$from
+            ]);
             $this->logger->logInfo('Inscription finished successfully for user #'.$inscription->user_id);
             $this->redirectUser($from, BlocksHelper::ONECLICK_SUCCESSFULL_INSCRIPTION);
 

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -98,7 +98,10 @@ class ResponseController
             }
             $commitResponse = $this->webpayplusTransbankSdk->commitTransaction($transaction->order_id, $transaction->token);
             $this->completeWooCommerceOrder($wooCommerceOrder, $commitResponse, $transaction);
-            do_action('transbank_webpay_plus_transaction_approved', $wooCommerceOrder, $transaction);
+            do_action('wc_transbank_webpay_plus_transaction_approved', [
+                'order' => $wooCommerceOrder,
+                'transbankTransaction' => $transaction
+            ]);
             return wp_redirect($wooCommerceOrder->get_checkout_order_received_url());
 
         } catch (TimeoutWebpayException $e) {
@@ -131,19 +134,29 @@ class ResponseController
             $transaction = $e->getTransaction();
             $wooCommerceOrder = $this->getWooCommerceOrderById($transaction->order_id);
             $this->setWooCommerceOrderAsFailed($wooCommerceOrder, $transaction, null, $transaction->token);
-            do_action('transbank_webpay_plus_transaction_failed', $wooCommerceOrder, $transaction, null);
+            do_action('wc_transbank_webpay_plus_transaction_failed', [
+                'order' => $wooCommerceOrder,
+                'transbankTransaction' => $transaction
+            ]);
             return wp_redirect($wooCommerceOrder->get_checkout_order_received_url());
         } catch (RejectedCommitWebpayException $e) {
             $transaction = $e->getTransaction();
             $wooCommerceOrder = $this->getWooCommerceOrderById($transaction->order_id);
             $this->setWooCommerceOrderAsFailed($wooCommerceOrder, $transaction, $e->getCommitResponse(), $transaction->token);
-            do_action('transbank_webpay_plus_transaction_failed', $wooCommerceOrder, $transaction, $e->getCommitResponse());
+            do_action('wc_transbank_webpay_plus_transaction_failed', [
+                'order' => $wooCommerceOrder,
+                'transbankTransaction' => $transaction,
+                'transbankResponse' => $e->getCommitResponse()
+            ]);
             return wp_redirect($wooCommerceOrder->get_checkout_order_received_url());
         } catch (CommitWebpayException $e) {
             $transaction = $e->getTransaction();
             $wooCommerceOrder = $this->getWooCommerceOrderById($transaction->order_id);
             $this->setWooCommerceOrderAsFailed($wooCommerceOrder, $transaction, null, $transaction->token);
-            do_action('transbank_webpay_plus_transaction_failed', $wooCommerceOrder, $transaction, null);
+            do_action('wc_transbank_webpay_plus_transaction_failed', [
+                'order' => $wooCommerceOrder,
+                'transbankTransaction' => $transaction
+            ]);
             return wp_redirect($wooCommerceOrder->get_checkout_order_received_url());
         } catch (\Exception $e) {
             $this->throwError($e->getMessage());


### PR DESCRIPTION
This PR implements fixes for the webhooks associated with Webpay Plus and Oneclick transactions.

## Webhooks:

### Webpay Plus
- wc_transbank_webpay_plus_transaction_approved
- wc_transbank_webpay_plus_transaction_failed

### Oneclick
- wc_transbank_oneclick_inscription_finished
- wc_transbank_oneclick_inscription_approved
- wc_transbank_oneclick_refund_approved
- wc_transbank_oneclick_refund_failed
- wc_transbank_oneclick_transaction_approved
- wc_transbank_oneclick_transaction_failed

Test

Create Webhook
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/b9d1269e-36af-4f2b-8f41-532256ff3039)

Webhook activation
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/fd0c56ca-f1a0-4178-b08f-ca8717ab7e48)

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/ea8b12e5-e4ac-4717-9cb5-dd6950b1a2ec)
