### PR TITLE
fix: buy order generation

### DIFF
--- a/plugin/src/OneclickTransbankSdk.php
+++ b/plugin/src/OneclickTransbankSdk.php
@@ -370,9 +370,8 @@ class OneclickTransbankSdk extends TransbankSdk
 
     public function authorize($orderId, $amount, $username, $token) {
         global $wpdb;
-        $randomNumber = uniqid();
-        $parentBuyOrder = 'wc:'.$randomNumber.':'.$orderId;
-        $childBuyOrder = 'wc:child:'.$randomNumber.':'.$orderId;
+        $parentBuyOrder = $this->generateBuyOrder('wc:', $orderId);
+        $childBuyOrder = $this->generateBuyOrder('wc:child:', $orderId);
         $params = [
             'orderId'           => $orderId,
             'buyOrder'          => $parentBuyOrder,

--- a/plugin/src/TransbankSdk.php
+++ b/plugin/src/TransbankSdk.php
@@ -88,5 +88,11 @@ class TransbankSdk
         TransbankExecutionErrorLog::create($orderId, $service, $product, $this->getEnviroment(), $this->getCommerceCode(), json_encode($data), $error, $originalError, $customError);
     }
 
-}
+    protected function generateBuyOrder($prefix, $orderId, $maxLength = 25){
+        $randomComponentLength = $maxLength - (strlen($prefix) + strlen((string)$orderId));
+        $randomComponent = openssl_random_pseudo_bytes(floor($randomComponentLength / 2));
+        $randToHexValue = bin2hex($randomComponent);
+        return $prefix . $randToHexValue . ":" . $orderId;
+    }
 
+}

--- a/plugin/src/WebpayplusTransbankSdk.php
+++ b/plugin/src/WebpayplusTransbankSdk.php
@@ -139,7 +139,7 @@ class WebpayplusTransbankSdk extends TransbankSdk
     {
         global $wpdb;
         $randomNumber = uniqid();
-        $buyOrder = 'wc:'.$randomNumber.':'.$orderId;
+        $buyOrder = $this->generateBuyOrder('wc:', $orderId);
         $sessionId = 'wc:sessionId:'.$randomNumber.':'.$orderId;
         $params = [
             'sessionId'  => $sessionId,


### PR DESCRIPTION
This PR fix the generation of buy order. 
Now this length must not exceed 26 characters.

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/101830551/cffdd280-eaf9-4faa-8c0e-b5137391e859)


![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/101830551/ae194cea-05bc-428a-9a0d-54d378c49085)
