### PR TITLE
docs: add release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Para poder operar con dinero real (ambiente de **producción**), debes completar
 A continuación, encontrarás información necesaria para el desarrollo de este plugin. 
 
 ## Requisitos 
-* PHP 7.0 o superior
-* Woocommerce 3.4 o superior
+* PHP 7.4 o superior
+* Woocommerce 7.0 o superior
 
 ## Dependencias
 

--- a/plugin/readme.txt
+++ b/plugin/readme.txt
@@ -14,6 +14,10 @@ Recibe pagos en línea con tarjetas de crédito, débito y prepago en tu WooComm
 Recibe pagos en línea con tarjetas de crédito, débito y prepago en tu WooCommerce a través de Webpay Plus y Webpay Oneclick
 
 == Changelog ==
+= 1.7.1 =
+* Se corrige el formato de la nota de reembolso de pedidos.
+* Se corrige un bug en la generación de la orden de compra.
+
 = 1.7.0 =
 * Se corrige el funcionamiento de los webhooks implementados para desarrollo de terceros.
 * Se ofuscan datos sensibles en el log cuando el entorno es producción.
@@ -144,6 +148,10 @@ Arreglado:
 * Initial release.
 
 == Upgrade Notice ==
+= 1.7.1 =
+* Se corrige el formato de la nota de reembolso de pedidos.
+* Se corrige un bug en la generación de la orden de compra.
+
 = 1.7.0 =
 * Se corrige el funcionamiento de los webhooks implementados para desarrollo de terceros.
 * Se ofuscan datos sensibles en el log cuando el entorno es producción.


### PR DESCRIPTION
Prepare release 1.7.1 for develop.

Add this changes:

- The format of the refund note for orders has been corrected.
- A bug in the buy order generation has been fixed.
- Removes unnecessary texts.