### PR TITLE
feat: standardizes operation result messages for orders

### DIFF
--- a/plugin/shared/Helpers/TbkConstants.php
+++ b/plugin/shared/Helpers/TbkConstants.php
@@ -59,9 +59,10 @@ class TbkConstants
     ];
 
     const PAYMENT_TYPE_CREDIT = "Crédito";
+    const PAYMENT_TYPE_DEBIT = "Débito";
 
     const PAYMENT_TYPE = [
-        "VD" => "Débito",
+        "VD" => self::PAYMENT_TYPE_DEBIT,
         "VN" => self::PAYMENT_TYPE_CREDIT,
         "VC" => self::PAYMENT_TYPE_CREDIT,
         "SI" => self::PAYMENT_TYPE_CREDIT,

--- a/plugin/shared/Helpers/TbkConstants.php
+++ b/plugin/shared/Helpers/TbkConstants.php
@@ -58,15 +58,15 @@ class TbkConstants
         "VP" => "Venta Prepago"
     ];
 
-    const PAYMENT_TYPE_CREDITO = "Crédito";
+    const PAYMENT_TYPE_CREDIT = "Crédito";
 
     const PAYMENT_TYPE = [
         "VD" => "Débito",
-        "VN" => TbkConstants::PAYMENT_TYPE_CREDITO,
-        "VC" => TbkConstants::PAYMENT_TYPE_CREDITO,
-        "SI" => TbkConstants::PAYMENT_TYPE_CREDITO,
-        "S2" => TbkConstants::PAYMENT_TYPE_CREDITO,
-        "NC" => TbkConstants::PAYMENT_TYPE_CREDITO,
+        "VN" => self::PAYMENT_TYPE_CREDIT,
+        "VC" => self::PAYMENT_TYPE_CREDIT,
+        "SI" => self::PAYMENT_TYPE_CREDIT,
+        "S2" => self::PAYMENT_TYPE_CREDIT,
+        "NC" => self::PAYMENT_TYPE_CREDIT,
         "VP" => "Prepago"
     ];
 

--- a/plugin/shared/Helpers/TbkConstants.php
+++ b/plugin/shared/Helpers/TbkConstants.php
@@ -60,6 +60,7 @@ class TbkConstants
 
     const PAYMENT_TYPE_CREDIT = "Crédito";
     const PAYMENT_TYPE_DEBIT = "Débito";
+    const PAYMENT_TYPE_PREPAID = "Prepago";
 
     const PAYMENT_TYPE = [
         "VD" => self::PAYMENT_TYPE_DEBIT,
@@ -68,7 +69,7 @@ class TbkConstants
         "SI" => self::PAYMENT_TYPE_CREDIT,
         "S2" => self::PAYMENT_TYPE_CREDIT,
         "NC" => self::PAYMENT_TYPE_CREDIT,
-        "VP" => "Prepago"
+        "VP" => self::PAYMENT_TYPE_PREPAID
     ];
 
     const INSTALLMENT_TYPE = [

--- a/plugin/shared/Helpers/TbkConstants.php
+++ b/plugin/shared/Helpers/TbkConstants.php
@@ -78,7 +78,17 @@ class TbkConstants
         "S2" => "2 cuotas sin interés",
         "NC" => "N cuotas sin interés"
     ];
-    
+
+    const STATUS_DESCRIPTION =  [
+        'INITIALIZED' => 'Inicializada',
+        'AUTHORIZED' => 'Autorizada',
+        'REVERSED' => 'Reversada',
+        'FAILED' => 'Fallida',
+        'NULLIFIED' => 'Anulada',
+        'PARTIALLY_NULLIFIED' => 'Parcialmente anulada',
+        'CAPTURED' => 'Capturada',
+    ];
+
     const ECOMMERCE_WOOCOMMERCE = 'woocommerce';
 
     const REPO_WOOCOMMERCE = 'TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest';

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -340,6 +340,8 @@ class ResponseController
         $status = TbkResponseUtil::getStatus($commitResponse->getStatus());
         $paymentType = TbkResponseUtil::getPaymentType($commitResponse->getPaymentTypeCode());
         $installmentType = TbkResponseUtil::getInstallmentType($commitResponse->getPaymentTypeCode());
+        $formattedAccountingDate = TbkResponseUtil::getAccountingDate($commitResponse->getAccountingDate());
+
         $transactionDate = new DateTime($commitResponse->getTransactionDate(), new DateTimeZone('UTC'));
         $transactionDate->setTimeZone(new DateTimeZone(wc_timezone_string()));
         $formattedDate = $transactionDate->format('d-m-Y / H:i:s');
@@ -359,6 +361,7 @@ class ResponseController
                 <strong>Número de cuotas: </strong>{$commitResponse->getInstallmentsNumber()} <br />
                 <strong>Monto de cada cuota: </strong>{$commitResponse->getInstallmentsAmount()} <br />
                 <strong>Fecha:</strong> {$formattedDate} <br />
+                <strong>Fecha contable:</strong> {$formattedAccountingDate} <br />
                 <strong>Token:</strong> {$tbkToken} <br />
             </div>
         ";

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -4,7 +4,6 @@ namespace Transbank\WooCommerce\WebpayRest\Controllers;
 
 use DateTime;
 use DateTimeZone;
-use TbkResponseUtil;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 use Transbank\WooCommerce\WebpayRest\Models\Transaction;
 use Transbank\WooCommerce\WebpayRest\Helpers\HposHelper;

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -214,7 +214,7 @@ class ResponseController
         $hPosHelper->updateMeta($wooCommerceOrder, 'webpay_transaction_id', $webpayTransaction->id);
         $hPosHelper->updateMeta($wooCommerceOrder, 'transactionResponse', json_encode($result));
 
-        $message = 'Pago exitoso con Webpay Plus';
+        $message = 'Webpay Plus: Pago exitoso';
 
         $this->addOrderDetailsOnNotes(
             $amount,
@@ -249,7 +249,7 @@ class ResponseController
         $_SESSION['woocommerce_order_failed'] = true;
         $wooCommerceOrder->update_status('failed');
         if ($result !== null) {
-            $message = 'Pago rechazado';
+            $message = 'Webpay Plus: Pago rechazado';
             list($authorizationCode, $amount, $sharesNumber, $transactionResponse, $paymentCodeResult, $date_accepted, $sharesAmount, $paymentType) = $this->getTransactionDetails($result);
             $cardNumber = isset($result->cardDetail['card_number']) ? $result->cardDetail['card_number'] : '-';
 

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -16,6 +16,7 @@ use Transbank\Plugin\Exceptions\Webpay\CommitWebpayException;
 use Transbank\Plugin\Exceptions\Webpay\InvalidStatusWebpayException;
 use Transbank\Plugin\Exceptions\Webpay\RejectedCommitWebpayException;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkFactory;
+use Transbank\WooCommerce\WebpayRest\Helpers\TbkResponseUtil;
 use WC_Order;
 
 class ResponseController

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -227,7 +227,7 @@ class ResponseController
             $sharesNumber,
             $paymentType,
             $paymentCodeResult,
-            $webpayTransaction,
+            $webpayTransaction->token,
             $date,
             $wooCommerceOrder
         );
@@ -265,7 +265,7 @@ class ResponseController
                 $sharesNumber,
                 $paymentType,
                 $paymentCodeResult,
-                $webpayTransaction,
+                $webpayTransaction->token,
                 $date,
                 $wooCommerceOrder
             );
@@ -351,7 +351,7 @@ class ResponseController
         $sharesNumber,
         $paymentType,
         $paymentCodeResult,
-        $webpayTransaction,
+        $token,
         $date,
         WC_Order $wooCommerceOrder
     ) {
@@ -372,7 +372,7 @@ class ResponseController
                 <strong>Tipo de cuota: </strong>{$paymentCodeResult} <br />
                 <strong>Número de cuotas: </strong>{$sharesNumber} <br />
                 <strong>Monto de cada cuota: </strong>{$sharesAmount} <br />
-                <strong>Token:</strong> {$webpayTransaction->token} <br />
+                <strong>Token:</strong> {$token} <br />
                 <strong>Fecha:</strong> {$date} <br />
             </div>
         ";

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -301,7 +301,7 @@ class ResponseController
         }
         $paymentCodeResult = self::getHumanReadableInstallmentsType($paymentTypeCode);
 
-        $paymentType = $this->getHumanReadablePaymentType($paymentTypeCode);
+        $paymentType = TbkResponseUtil::getPaymentType($paymentTypeCode);
 
         $transactionDate = isset($result->transactionDate) ? $result->transactionDate : null;
         $date_accepted = new DateTime($transactionDate, new DateTimeZone('UTC'));
@@ -364,27 +364,6 @@ class ResponseController
             </div>
         ";
         $wooCommerceOrder->add_order_note($transactionDetails);
-    }
-
-    /**
-     * @param $paymentTypeCode
-     *
-     * @return string|void
-     */
-    public static function getHumanReadablePaymentType($paymentTypeCode)
-    {
-        if ($paymentTypeCode != null) {
-            $paymentType = __('Crédito', 'transbank_wc_plugin');
-        } else {
-            $paymentType = '';
-        }
-        if ($paymentTypeCode == 'VD') {
-            $paymentType = __('Débito', 'transbank_wc_plugin');
-        } elseif ($paymentTypeCode == 'VP') {
-            $paymentType = __('Prepago', 'transbank_wc_plugin');
-        }
-
-        return $paymentType;
     }
 
     /**

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -322,19 +322,11 @@ class ResponseController
     }
 
     /**
-     * @param $amount
-     * @param array $result
-     * @param $sharesAmount
-     * @param string $message
-     * @param $transactionResponse
-     * @param $authorizationCode
-     * @param $cardNumber
-     * @param $sharesNumber
-     * @param $paymentType
-     * @param $paymentCodeResult
-     * @param $webpayTransaction
-     * @param $date
      * @param WC_Order $wooCommerceOrder
+     * @param TransactionCommitResponse $commitResponse
+     * @param string $titleMessage
+     * @param string $tbkToken
+     * @return void
      */
     protected function addOrderDetailsOnNotes(
         WC_Order $wooCommerceOrder,

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -213,7 +213,7 @@ class ResponseController
         $paymentType = TbkResponseUtil::getPaymentType($commitResponse->getPaymentTypeCode());
         $date_accepted = new DateTime($commitResponse->getTransactionDate(), new DateTimeZone('UTC'));
         $date_accepted->setTimeZone(new DateTimeZone(wc_timezone_string()));
-        $date = $date_accepted->format('d-m-Y / H:i:s');
+        $date = $date_accepted->format('d-m-Y H:i:s P');
 
         $hPosHelper = new HposHelper();
         $hPosHelper->updateMeta($wooCommerceOrder, 'transactionStatus', $status);
@@ -351,7 +351,7 @@ class ResponseController
 
         $transactionDate = new DateTime($commitResponse->getTransactionDate(), new DateTimeZone('UTC'));
         $transactionDate->setTimeZone(new DateTimeZone(wc_timezone_string()));
-        $formattedDate = $transactionDate->format('d-m-Y / H:i:s');
+        $formattedDate = $transactionDate->format('d-m-Y H:i:s P');
 
         $transactionDetails = "
             <div class='transbank_response_note'>

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -45,26 +45,6 @@ class ResponseController
     }
 
     /**
-     * @param $paymentTypeCode
-     *
-     * @return string
-     */
-    public static function getHumanReadableInstallmentsType($paymentTypeCode): string
-    {
-        $installmentTypes = [
-            'VD' => 'Venta Débito',
-            'VN' => 'Venta Normal',
-            'VC' => 'Venta en cuotas',
-            'SI' => '3 cuotas sin interés',
-            'S2' => '2 cuotas sin interés',
-            'NC' => 'N cuotas sin interés',
-        ];
-        $paymentCodeResult = isset($installmentTypes[$paymentTypeCode]) ? $installmentTypes[$paymentTypeCode] : 'Sin cuotas';
-
-        return $paymentCodeResult;
-    }
-
-    /**
      * @throws \GuzzleHttp\Exception\GuzzleException
      * @throws \Transbank\Plugin\Exceptions\TokenNotFoundOnDatabaseException
      */
@@ -299,7 +279,7 @@ class ResponseController
         } else {
             $transactionResponse = 'Transacción Rechazada';
         }
-        $paymentCodeResult = self::getHumanReadableInstallmentsType($paymentTypeCode);
+        $paymentCodeResult = TbkResponseUtil::getInstallmentType($paymentTypeCode);
 
         $paymentType = TbkResponseUtil::getPaymentType($paymentTypeCode);
 

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -336,6 +336,9 @@ class ResponseController
         string $tbkToken
     ) {
         $amountFormatted = number_format($commitResponse->getAmount(), 0, ',', '.');
+        $transactionDate = new DateTime($commitResponse->getTransactionDate(), new DateTimeZone('UTC'));
+        $transactionDate->setTimeZone(new DateTimeZone(wc_timezone_string()));
+        $formattedDate = $transactionDate->format('d-m-Y / H:i:s');
         $transactionDetails = "
             <div class='transbank_response_note'>
                 <p><h3>{$titleMessage}</h3></p>
@@ -350,8 +353,8 @@ class ResponseController
                 <strong>Tipo de cuota: </strong>{$commitResponse->getPaymentTypeCode()} <br />
                 <strong>Número de cuotas: </strong>{$commitResponse->getInstallmentsNumber()} <br />
                 <strong>Monto de cada cuota: </strong>{$commitResponse->getInstallmentsAmount()} <br />
+                <strong>Fecha:</strong> {$formattedDate} <br />
                 <strong>Token:</strong> {$tbkToken} <br />
-                <strong>Fecha:</strong> {$commitResponse->getTransactionDate()} <br />
             </div>
         ";
         $wooCommerceOrder->add_order_note($transactionDetails);

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -246,7 +246,7 @@ class ResponseController
                 $webpayTransaction->token
             );
 
-            $this->logger->logError('C.5. Respuesta de tbk commit fallido => token: '.$token);
+            $this->logger->logError('C.5. Respuesta de tbk commit fallido => token: '.$webpayTransaction->token);
             $this->logger->logError(json_encode($commitResponse));
         }
 

--- a/plugin/src/Controllers/ResponseController.php
+++ b/plugin/src/Controllers/ResponseController.php
@@ -374,7 +374,6 @@ class ResponseController
                 <strong>Monto de cada cuota: </strong>{$sharesAmount} <br />
                 <strong>Token:</strong> {$webpayTransaction->token} <br />
                 <strong>Fecha:</strong> {$date} <br />
-                <strong>ID interno: </strong>{$webpayTransaction->id} <br />
             </div>
         ";
         $wooCommerceOrder->add_order_note($transactionDetails);

--- a/plugin/src/Controllers/ThankYouPageController.php
+++ b/plugin/src/Controllers/ThankYouPageController.php
@@ -45,11 +45,12 @@ class ThankYouPageController
             $firstTransaction = $finalResponse->details[0] ?? null;
             $responseCode = $firstTransaction->responseCode ?? null;
             $status = $firstTransaction->status ?? null;
+            $paymentTypeCode = $firstTransaction->paymentTypeCode;
             $responseTitle = ($responseCode === 0 && $status === 'AUTHORIZED') ? 'Transacción Aprobada' : 'Transacción Rechazada';
             $dateAccepted = new DateTime($finalResponse->transactionDate ?? null, new DateTimeZone('UTC'));
             $dateAccepted->setTimeZone(new DateTimeZone(wc_timezone_string()));
-            $paymentType = TbkResponseUtil::getPaymentType($firstTransaction->paymentTypeCode);
-            $installmentType = ResponseController::getHumanReadableInstallmentsType($firstTransaction->paymentTypeCode);
+            $paymentType = TbkResponseUtil::getPaymentType($paymentTypeCode);
+            $installmentType = TbkResponseUtil::getInstallmentType($paymentTypeCode);
             require_once __DIR__.'/../../views/order-summary-oneclick.php';
 
             return;

--- a/plugin/src/Controllers/ThankYouPageController.php
+++ b/plugin/src/Controllers/ThankYouPageController.php
@@ -4,6 +4,7 @@ namespace Transbank\WooCommerce\WebpayRest\Controllers;
 
 use DateTime;
 use DateTimeZone;
+use Transbank\WooCommerce\WebpayRest\Helpers\TbkResponseUtil;
 use Transbank\WooCommerce\WebpayRest\Models\Transaction;
 use Transbank\WooCommerce\WebpayRest\PaymentGateways\WC_Gateway_Transbank_Oneclick_Mall_REST;
 use Transbank\WooCommerce\WebpayRest\PaymentGateways\WC_Gateway_Transbank_Webpay_Plus_REST;
@@ -47,7 +48,7 @@ class ThankYouPageController
             $responseTitle = ($responseCode === 0 && $status === 'AUTHORIZED') ? 'Transacción Aprobada' : 'Transacción Rechazada';
             $dateAccepted = new DateTime($finalResponse->transactionDate ?? null, new DateTimeZone('UTC'));
             $dateAccepted->setTimeZone(new DateTimeZone(wc_timezone_string()));
-            $paymentType = ResponseController::getHumanReadablePaymentType($firstTransaction->paymentTypeCode);
+            $paymentType = TbkResponseUtil::getPaymentType($firstTransaction->paymentTypeCode);
             $installmentType = ResponseController::getHumanReadableInstallmentsType($firstTransaction->paymentTypeCode);
             require_once __DIR__.'/../../views/order-summary-oneclick.php';
 

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace Transbank\WooCommerce\WebpayRest\Helpers;
+
 use Transbank\Plugin\Helpers\TbkConstants;
 
 /**

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -2,23 +2,55 @@
 
 use Transbank\Plugin\Helpers\TbkConstants;
 
-class TbkResponseUtil {
-    public static function getPaymentType(string $paymentType) {
-        return TbkConstants::PAYMENT_TYPE[$paymentType]?? $paymentType;
+/**
+ * Utility class for handling Transbank responses.
+ */
+class TbkResponseUtil
+{
+    /**
+     * Get the payment type from its code.
+     *
+     * @param string $paymentType The code of the payment type.
+     * @return string The corresponding payment type.
+     */
+    public static function getPaymentType(string $paymentType)
+    {
+        return TbkConstants::PAYMENT_TYPE[$paymentType] ?? $paymentType;
     }
 
-    public static function getInstallmentType(string $paymentType) {
-        return TbkConstants::INSTALLMENT_TYPE[$paymentType]?? $paymentType;
+    /**
+     * Get the installment type from the payment type response.
+     *
+     * @param string $paymentType The code of the installment type.
+     * @return string The corresponding installment type.
+     */
+    public static function getInstallmentType(string $paymentType)
+    {
+        return TbkConstants::INSTALLMENT_TYPE[$paymentType] ?? $paymentType;
     }
 
-    public static function getStatus(string $status) {
-        return TbkConstants::STATUS_DESCRIPTION[$status]?? $status;
+    /**
+     * Get the transaction status description from response status.
+     *
+     * @param string $status The code of the transaction status.
+     * @return string The description of the corresponding transaction status.
+     */
+    public static function getStatus(string $status)
+    {
+        return TbkConstants::STATUS_DESCRIPTION[$status] ?? $status;
     }
 
-    public static function getAccountingDate(string $accountingDate) {
+    /**
+     * Get the formatted accounting date from response.
+     *
+     * @param string $accountingDate The accounting date in 'md' format.
+     * @return string The accounting date in 'mm-dd' format.
+     */
+    public static function getAccountingDate(string $accountingDate)
+    {
         $date = DateTime::createFromFormat('md', $accountingDate);
 
-        if(!$date) {
+        if (!$date) {
             return $accountingDate;
         }
 

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -2,6 +2,7 @@
 
 namespace Transbank\WooCommerce\WebpayRest\Helpers;
 
+use DateTime;
 use Transbank\Plugin\Helpers\TbkConstants;
 
 /**

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -29,7 +29,7 @@ class TbkResponseUtil
      */
     public static function getInstallmentType(string $paymentType)
     {
-        return TbkConstants::INSTALLMENT_TYPE[$paymentType] ?? $paymentType;
+        return TbkConstants::PAYMENT_TYPE_CODE[$paymentType] ?? $paymentType;
     }
 
     /**

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -1,0 +1,22 @@
+<?php
+
+use Transbank\Plugin\Helpers\TbkConstants;
+
+class TbkResponseUtil {
+    public static function getPaymentType(string $paymentType) {
+        return TbkConstants::PAYMENT_TYPE[$paymentType]?? $paymentType;
+    }
+
+    public static function getInstallmentType(string $paymentType) {
+        return TbkConstants::INSTALLMENT_TYPE[$paymentType]?? $paymentType;
+    }
+
+    public static function getStatus(string $status) {
+        return TbkConstants::STATUS_DESCRIPTION[$status]?? $status;
+    }
+
+    public static function getAccountingDate(string $accountingDate) {
+        $date = DateTime::createFromFormat('md', $accountingDate);
+        return $date->format('m-d');
+    }
+}

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -17,6 +17,11 @@ class TbkResponseUtil {
 
     public static function getAccountingDate(string $accountingDate) {
         $date = DateTime::createFromFormat('md', $accountingDate);
+
+        if(!$date) {
+            return $accountingDate;
+        }
+
         return $date->format('m-d');
     }
 }

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -3,6 +3,7 @@
 namespace Transbank\WooCommerce\WebpayRest\PaymentGateways;
 
 use Exception;
+use TbkResponseUtil;
 use Throwable;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkFactory;
@@ -422,22 +423,26 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
         $firstDetail = $response->getDetails()[0];
         $amountFormatted = number_format($firstDetail->getAmount(), 0, ',', '.');
         $sharesAmount = $firstDetail->getInstallmentsAmount() ?? '-';
+        $status = TbkResponseUtil::getStatus($firstDetail->getStatus());
+        $paymentType = TbkResponseUtil::getPaymentType($firstDetail->getPaymentTypeCode());
+        $formattedAccountingDate = TbkResponseUtil::getAccountingDate($response->getAccountingDate());
+
         $transactionDetails = "
             <div class='transbank_response_note'>
                 <p><h3>{$message}</h3></p>
 
-                <strong>Estado: </strong>{$firstDetail->getStatus()} <br />
+                <strong>Estado: </strong>{$status} <br />
                 <strong>Orden de compra mall: </strong>{$response->getBuyOrder()} <br />
                 <strong>Orden de compra tienda: </strong>{$firstDetail->getBuyOrder()} <br />
                 <strong>Código de autorización: </strong>{$firstDetail->getAuthorizationCode()} <br />
                 <strong>Últimos dígitos tarjeta: </strong>{$response->getCardNumber()} <br />
                 <strong>Monto: </strong>$ {$amountFormatted} <br />
                 <strong>Código de respuesta: </strong>{$firstDetail->getResponseCode()} <br />
-                <strong>Tipo de pago: </strong>{$firstDetail->getPaymentTypeCode()} <br />
+                <strong>Tipo de pago: </strong>{$paymentType} <br />
                 <strong>Número de cuotas: </strong>{$firstDetail->getInstallmentsNumber()} <br />
                 <strong>Monto de cada cuota: </strong>{$sharesAmount} <br />
                 <strong>Fecha:</strong> {$response->getTransactionDate()} <br />
-                <strong>Fecha contable:</strong> {$response->getAccountingDate()} <br />
+                <strong>Fecha contable:</strong> {$formattedAccountingDate} <br />
             </div>
         ";
         $wooCommerceOrder->add_order_note($transactionDetails);

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -427,8 +427,8 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
                 <p><h3>{$message}</h3></p>
 
                 <strong>Estado: </strong>{$firstDetail->getStatus()} <br />
-                <strong>Orden de compra principal: </strong>{$response->getBuyOrder()} <br />
-                <strong>Orden de compra: </strong>{$firstDetail->getBuyOrder()} <br />
+                <strong>Orden de compra mall: </strong>{$response->getBuyOrder()} <br />
+                <strong>Orden de compra tienda: </strong>{$firstDetail->getBuyOrder()} <br />
                 <strong>Código de autorización: </strong>{$firstDetail->getAuthorizationCode()} <br />
                 <strong>Últimos dígitos tarjeta: </strong>{$response->getCardNumber()} <br />
                 <strong>Monto: </strong>$ {$amountFormatted} <br />

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -2,6 +2,8 @@
 
 namespace Transbank\WooCommerce\WebpayRest\PaymentGateways;
 
+use DateTime;
+use DateTimeZone;
 use Exception;
 use TbkResponseUtil;
 use Throwable;
@@ -428,6 +430,10 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
         $installmentType = TbkResponseUtil::getInstallmentType($firstDetail->getPaymentTypeCode());
         $formattedAccountingDate = TbkResponseUtil::getAccountingDate($response->getAccountingDate());
 
+        $transactionDate = new DateTime($response->getTransactionDate(), new DateTimeZone('UTC'));
+        $transactionDate->setTimeZone(new DateTimeZone(wc_timezone_string()));
+        $formattedDate = $transactionDate->format('d-m-Y H:i:s P');
+
         $transactionDetails = "
             <div class='transbank_response_note'>
                 <p><h3>{$message}</h3></p>
@@ -443,7 +449,7 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
                 <strong>Tipo de cuota: </strong>{$installmentType} <br />
                 <strong>Número de cuotas: </strong>{$firstDetail->getInstallmentsNumber()} <br />
                 <strong>Monto de cada cuota: </strong>{$sharesAmount} <br />
-                <strong>Fecha:</strong> {$response->getTransactionDate()} <br />
+                <strong>Fecha:</strong> {$formattedDate} <br />
                 <strong>Fecha contable:</strong> {$formattedAccountingDate} <br />
             </div>
         ";

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -19,6 +19,7 @@ use Transbank\Plugin\Exceptions\Oneclick\RejectedRefundOneclickException;
 use Transbank\Plugin\Exceptions\Oneclick\RefundOneclickException;
 use Transbank\Plugin\Exceptions\Oneclick\NotFoundTransactionOneclickException;
 use Transbank\Plugin\Exceptions\Oneclick\GetTransactionOneclickException;
+use Transbank\WooCommerce\WebpayRest\Helpers\TbkResponseUtil;
 use Transbank\WooCommerce\WebpayRest\Tokenization\WC_Payment_Token_Oneclick;
 use WC_Order;
 use WC_Payment_Gateway_CC;

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -518,7 +518,7 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
             if (wc()->cart) {
                 wc()->cart->empty_cart();
             }
-            $this->add_order_notes($order, $authorizeResponse, 'Oneclick: Transacción Aprobada');
+            $this->add_order_notes($order, $authorizeResponse, 'Oneclick: Pago exitoso');
             do_action('wc_transbank_oneclick_transaction_approved', ['order' => $order->get_data()]);
             return [
                 'result'   => 'success',
@@ -533,11 +533,11 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
             $order->add_order_note('Transacción con problemas de autorización');
         } catch (RejectedAuthorizeOneclickException $e) {
             $order->update_status('failed');
-            $this->add_order_notes($order, $e->getAuthorizeResponse(), 'Oneclick: Transacción Rechazada');
+            $this->add_order_notes($order, $e->getAuthorizeResponse(), 'Oneclick: Pago rechazado');
             $order->add_order_note('Transacción rechazada');
         } catch (ConstraintsViolatedAuthorizeOneclickException $e) {
             $order->update_status('failed');
-            $this->add_order_notes($order, $e->getAuthorizeResponse(), 'Oneclick: Transacción Rechazada');
+            $this->add_order_notes($order, $e->getAuthorizeResponse(), 'Oneclick: Pago rechazado');
             $order->add_order_note('CONSTRAINTS_VIOLATED: '.$e->getMessage());
         }
 

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -423,7 +423,6 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
     {
         $firstDetail = $response->getDetails()[0];
         $amountFormatted = number_format($firstDetail->getAmount(), 0, ',', '.');
-        $sharesAmount = $firstDetail->getInstallmentsAmount() ?? '-';
         $status = TbkResponseUtil::getStatus($firstDetail->getStatus());
         $paymentType = TbkResponseUtil::getPaymentType($firstDetail->getPaymentTypeCode());
         $installmentType = TbkResponseUtil::getInstallmentType($firstDetail->getPaymentTypeCode());
@@ -447,7 +446,7 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
                 <strong>Tipo de pago: </strong>{$paymentType} <br />
                 <strong>Tipo de cuota: </strong>{$installmentType} <br />
                 <strong>Número de cuotas: </strong>{$firstDetail->getInstallmentsNumber()} <br />
-                <strong>Monto de cada cuota: </strong>{$sharesAmount} <br />
+                <strong>Monto de cada cuota: </strong>{$firstDetail->getInstallmentsAmount()} <br />
                 <strong>Fecha:</strong> {$formattedDate} <br />
                 <strong>Fecha contable:</strong> {$formattedAccountingDate} <br />
             </div>

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -5,7 +5,6 @@ namespace Transbank\WooCommerce\WebpayRest\PaymentGateways;
 use DateTime;
 use DateTimeZone;
 use Exception;
-use TbkResponseUtil;
 use Throwable;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkFactory;

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -419,12 +419,12 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
 
     protected function add_order_notes(WC_Order $wooCommerceOrder, $response, $message)
     {
-        /** @var Transbank\Webpay\Oneclick\Responses\TransactionDetail $firstDetail */
         $firstDetail = $response->getDetails()[0];
         $amountFormatted = number_format($firstDetail->getAmount(), 0, ',', '.');
         $sharesAmount = $firstDetail->getInstallmentsAmount() ?? '-';
         $status = TbkResponseUtil::getStatus($firstDetail->getStatus());
         $paymentType = TbkResponseUtil::getPaymentType($firstDetail->getPaymentTypeCode());
+        $installmentType = TbkResponseUtil::getInstallmentType($firstDetail->getPaymentTypeCode());
         $formattedAccountingDate = TbkResponseUtil::getAccountingDate($response->getAccountingDate());
 
         $transactionDetails = "
@@ -439,6 +439,7 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
                 <strong>Monto: </strong>$ {$amountFormatted} <br />
                 <strong>Código de respuesta: </strong>{$firstDetail->getResponseCode()} <br />
                 <strong>Tipo de pago: </strong>{$paymentType} <br />
+                <strong>Tipo de cuota: </strong>{$installmentType} <br />
                 <strong>Número de cuotas: </strong>{$firstDetail->getInstallmentsNumber()} <br />
                 <strong>Monto de cada cuota: </strong>{$sharesAmount} <br />
                 <strong>Fecha:</strong> {$response->getTransactionDate()} <br />


### PR DESCRIPTION
This PR standardize the content of the order notes for Oneclick and Webpay transactions

Test

- [x] Webpay transaction approved 
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/5280933f-c155-4ad5-a621-97490a5dd195)
- [x] Webpay transaction rejected
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/01314df2-b679-440b-8506-058d20d243ef)
- [x] Webpay confirmation error
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/7e82144e-3efc-48ca-8682-ce2599c7baaa)
- [x] Oneclick transaction approved
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/7e2a60e2-3e70-4333-9825-07aa1cbfc048)
