### PR TITLE
feat: show cards based on environment

### DIFF
--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -252,7 +252,10 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
         if ('oneclick' !== strtolower($payment_token->get_type())) {
             return $item;
         }
-        $item['method']['last4'] = $payment_token->get_last4();
+        $cardEnvironment = $payment_token->get_environment();
+        $environmentSuffix = $cardEnvironment === Options::ENVIRONMENT_INTEGRATION ? ' [Test]' : '';
+
+        $item['method']['last4'] = $payment_token->get_last4().$environmentSuffix;
         $item['method']['brand'] = $payment_token->get_card_type();
 
         return $item;

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -103,6 +103,7 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
         add_filter('woocommerce_payment_methods_list_item', [$this, 'methods_list_item_oneclick'], null, 2);
         add_filter('woocommerce_payment_token_class', [$this, 'set_payment_token_class']);
         add_action('woocommerce_update_options_payment_gateways_' . $this->id, [$this, 'process_admin_options']);
+        add_filter('woocommerce_saved_payment_methods_list', [$this, 'get_saved_payment_methods_list'], 10, 2);
     }
 
     public function payment_fields()
@@ -247,16 +248,37 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
         // Todo: check if we need something here.
     }
 
+    public function get_saved_payment_methods_list($saved_methods, $customer_id)
+    {
+        $pluginEnvironment = $this->get_option('environment');
+        $oneclickCards = $saved_methods['oneclick'] ?? [];
+        $filteredCards = [];
+
+        foreach ($oneclickCards as $card) {
+            if ($card['method']['environment'] === $pluginEnvironment) {
+                $filteredCards[] = $card;
+            }
+        }
+
+        if (count($oneclickCards) > 0) {
+            $saved_methods['oneclick'] = $filteredCards;
+        }
+
+        return $saved_methods;
+    }
+
     public function methods_list_item_oneclick($item, $payment_token)
     {
         if ('oneclick' !== strtolower($payment_token->get_type())) {
             return $item;
         }
+
         $cardEnvironment = $payment_token->get_environment();
         $environmentSuffix = $cardEnvironment === Options::ENVIRONMENT_INTEGRATION ? ' [Test]' : '';
 
-        $item['method']['last4'] = $payment_token->get_last4().$environmentSuffix;
+        $item['method']['last4'] = $payment_token->get_last4() . $environmentSuffix;
         $item['method']['brand'] = $payment_token->get_card_type();
+        $item['method']['environment'] = $cardEnvironment;
 
         return $item;
     }


### PR DESCRIPTION
This PR adds the functionality to display cards based on the environment. It also adds the suffix 'Test' to the registered cards in the integration environment.

## Test

### Register card in integration environment
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/ab0087b2-3a70-47da-b862-2e772d4c06b5)
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/085acd3a-1015-4df1-b447-99a55dd31c24)

### No card in production environment
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/2091b40a-e119-4d01-a39f-cbc643f3075e)
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/d11b9273-0b96-4c9b-af14-7bf9971952d6)


### Register card in production environment
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/0ae3c28e-4aab-45fb-b71f-ce64dc2e8699)
