### PR TITLE
fix: remove deprecated hook

### DIFF
--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -245,11 +245,6 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
         }
     }
 
-    public static function subscription_payment_method_updated()
-    {
-        // Todo: check if we need something here.
-    }
-
     public function get_saved_payment_methods_list($saved_methods)
     {
         $pluginEnvironment = $this->get_option('environment');

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -45,8 +45,6 @@ add_action('wp_ajax_check_exist_tables', TableCheck::class.'::check');
 add_action('wp_ajax_get_transaction_status', TransactionStatusController::class.'::getStatus');
 add_action('woocommerce_before_cart', 'transbank_rest_before_cart');
 
-add_action('woocommerce_subscription_failing_payment_method_updated_transbank_oneclick_mall_rest', [WC_Gateway_Transbank_Oneclick_Mall_REST::class, 'subscription_payment_method_updated'], 10, 3);
-
 add_action('woocommerce_before_checkout_form', 'transbank_rest_check_cancelled_checkout');
 add_action('admin_enqueue_scripts', function () {
     wp_enqueue_style('tbk-styles', plugins_url('/css/tbk.css', __FILE__), [], '1.1');


### PR DESCRIPTION
This PR remove a deprecated hook and fix issue https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/issues/226

## Reference
https://woocommerce.com/document/subscriptions-query-monitor-warning/

## Test

No test for this PR :(