### PR TITLE
chore: add woocommerce as a dependency

### DIFF
--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -28,6 +28,7 @@ if (!defined('ABSPATH')) {
  * Plugin URI: https://www.transbankdevelopers.cl/plugin/woocommerce/webpay
  * Description: Recibe pagos en línea con Tarjetas de Crédito y Redcompra en tu WooCommerce a través de Webpay Plus y Webpay Oneclick.
  * Version: VERSION_REPLACE_HERE
+ * Requires Plugins: woocommerce
  * Author: TransbankDevelopers
  * Author URI: https://www.transbank.cl
  * WC requires at least: 7.0


### PR DESCRIPTION
This PR add the plugin Woocommerce as a dependency

## Test

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/23ba7a17-cabb-4966-b626-969ea6942760)
