### PR TITLE
fix: warning when input is null

### DIFF
--- a/plugin/src/Helpers/MaskData.php
+++ b/plugin/src/Helpers/MaskData.php
@@ -57,10 +57,11 @@ class MaskData
      * @return string a string masked.
      */
     private function mask($input, $pattern = null, $charsToKeep = 4 ){
-        $len = strlen($input);
+        $cleanInput = $input ?? '';
+        $len = strlen($cleanInput);
 
         if ( $pattern != null ) {
-           $patternPos = strpos($input, $pattern);
+           $patternPos = strpos($cleanInput, $pattern);
            if ( $patternPos === 0 ) {
                 $startString = $pattern;
             }
@@ -68,8 +69,8 @@ class MaskData
                 $endString = $pattern;
             }
         }
-        $startString = $startString ?? substr($input, 0, $charsToKeep);
-        $endString = $endString ?? substr($input, -$charsToKeep, $charsToKeep);
+        $startString = $startString ?? substr($cleanInput, 0, $charsToKeep);
+        $endString = $endString ?? substr($cleanInput, -$charsToKeep, $charsToKeep);
         $charsToReplace = $len - (strlen($startString) + strlen($endString));
         $replaceString = str_repeat("x", $charsToReplace);
         return $startString . $replaceString . $endString;

--- a/plugin/src/Helpers/MaskData.php
+++ b/plugin/src/Helpers/MaskData.php
@@ -62,11 +62,14 @@ class MaskData
      */
     private function mask($input, $pattern = null, $charsToKeep = 4)
     {
-        $cleanInput = $input ?? '';
-        $len = strlen($cleanInput);
+        if(is_null($input)) {
+            return '';
+        }
+
+        $len = strlen($input);
 
         if ($pattern != null) {
-            $patternPos = strpos($cleanInput, $pattern);
+            $patternPos = strpos($input, $pattern);
             if ($patternPos === 0) {
                 $startString = $pattern;
             } else {
@@ -74,8 +77,8 @@ class MaskData
             }
         }
 
-        $startString = $startString ?? substr($cleanInput, 0, $charsToKeep);
-        $endString = $endString ?? substr($cleanInput, -$charsToKeep, $charsToKeep);
+        $startString = $startString ?? substr($input, 0, $charsToKeep);
+        $endString = $endString ?? substr($input, -$charsToKeep, $charsToKeep);
         $charsToReplace = $len - (strlen($startString) + strlen($endString));
         $replaceString = str_repeat("x", $charsToReplace);
         return $startString . $replaceString . $endString;


### PR DESCRIPTION
This PR fix a warning message in the class `MaskData`, add protection when input is null in method `mask`.

## Test

### Write logs
![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/56d02b87-29a8-43f5-8eb2-30687877191c)
