### PR TITLE
fix: save in cache only log file name

### DIFF
--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -7,7 +7,8 @@ use Monolog\Handler\RotatingFileHandler;
 use Monolog\Formatter\LineFormatter;
 use Transbank\Plugin\Model\LogConfig;
 
-final class PluginLogger implements ILogger {
+final class PluginLogger implements ILogger
+{
 
     const CACHE_LOG_NAME = 'transbank_log_file_name';
 
@@ -21,7 +22,8 @@ final class PluginLogger implements ILogger {
      * output format : "[%datetime%] %channel%.%level_name%: %message% %context% %extra%\n"
      * @param Throwable $e
      */
-    public function __construct(LogConfig $config) {
+    public function __construct(LogConfig $config)
+    {
         $this->config = $config;
 
         $logFilePath = $this->getLogFilePath();
@@ -34,8 +36,11 @@ final class PluginLogger implements ILogger {
         $output = "%datetime% > %level_name% > %message% %context% %extra%\n";
         $formatter = new LineFormatter($output, $dateFormat);
 
-        $stream = new RotatingFileHandler($logFilePath,
-            100, Logger::DEBUG);
+        $stream = new RotatingFileHandler(
+            $logFilePath,
+            100,
+            Logger::DEBUG
+        );
         $stream->setFormatter($formatter);
 
         $this->logger = new Logger('transbank');
@@ -56,11 +61,13 @@ final class PluginLogger implements ILogger {
         return $logDir . $logFileName;
     }
 
-    public function getLogger(){
+    public function getLogger()
+    {
         return $this->logger;
     }
 
-    public function getConfig(){
+    public function getConfig()
+    {
         return $this->config;
     }
 
@@ -81,7 +88,7 @@ final class PluginLogger implements ILogger {
 
     public function getInfo()
     {
-        $files = glob($this->config->getLogDir().'/*.log');
+        $files = glob($this->config->getLogDir() . '/*.log');
         if (!$files) {
             return [
                 'dir'      => $this->config->getLogDir(),
@@ -94,7 +101,7 @@ final class PluginLogger implements ILogger {
         arsort($files);
 
         $logs = [];
-        foreach($files as $key=>$value) {
+        foreach ($files as $key => $value) {
             $logs[] = [
                 "filename" => basename($key),
                 "modified" => $value
@@ -114,7 +121,7 @@ final class PluginLogger implements ILogger {
         if ($filename == '') {
             return [];
         }
-        $fle = $this->config->getLogDir().'/'.$filename;
+        $fle = $this->config->getLogDir() . '/' . $filename;
         $content = file_get_contents($fle);
         if ($replaceNewline && $content !== false) {
             $content = str_replace("\n", '#@#', $content);

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -140,7 +140,7 @@ final class PluginLogger implements ILogger {
         return 'log_transbank_' . $uniqueId . 'log';
     }
 
-    private function getLogFileNameFromCache(): string | bool
+    private function getLogFileNameFromCache()
     {
         return get_transient(self::CACHE_LOG_NAME);
     }

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -25,15 +25,7 @@ final class PluginLogger implements ILogger {
         $this->config = $config;
 
         $logFilePath = $this->getLogFilePath();
-
-        $dateFormat = "Y-m-d H:i:s";
-        $output = "%datetime% > %level_name% > %message% %context% %extra%\n";
-        $formatter = new LineFormatter($output, $dateFormat);
-        $stream = new RotatingFileHandler($logFilePath,
-            100, Logger::DEBUG);
-        $stream->setFormatter($formatter);
-        $this->logger = new Logger('transbank');
-        $this->logger->pushHandler($stream);
+        $this->initializeLogger($logFilePath);
     }
 
     private function initializeLogger(string $logFilePath)

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -35,6 +35,21 @@ final class PluginLogger implements ILogger {
         $this->logger = new Logger('transbank');
         $this->logger->pushHandler($stream);
     }
+
+    private function initializeLogger(string $logFilePath)
+    {
+        $dateFormat = "Y-m-d H:i:s";
+        $output = "%datetime% > %level_name% > %message% %context% %extra%\n";
+        $formatter = new LineFormatter($output, $dateFormat);
+
+        $stream = new RotatingFileHandler($logFilePath,
+            100, Logger::DEBUG);
+        $stream->setFormatter($formatter);
+
+        $this->logger = new Logger('transbank');
+        $this->logger->pushHandler($stream);
+    }
+
     private function getLogFilePath(): string
     {
         $logFileName = $this->getLogFileNameFromCache();

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -137,7 +137,7 @@ final class PluginLogger implements ILogger {
     private function getLogFileName(): string
     {
         $uniqueId = uniqid('', true);
-        return 'log_transbank_' . $uniqueId . 'log';
+        return 'log_transbank_' . $uniqueId . '.log';
     }
 
     private function getLogFileNameFromCache()

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -23,16 +23,8 @@ final class PluginLogger implements ILogger {
      */
     public function __construct(LogConfig $config) {
         $this->config = $config;
-        $logFileName = $this->getLogFileNameFromCache();
 
-        if (!$logFileName) {
-            $logFileName = $this->getLogFileName();
-            $expireTime = strtotime('tomorrow') - time();
-            $this->saveLogFileNameInCache($logFileName, $expireTime);
-        }
-
-        $logDir = $this->getLogDir();
-        $logFilePath = $logDir . $logFileName;
+        $logFilePath = $this->getLogFilePath();
 
         $dateFormat = "Y-m-d H:i:s";
         $output = "%datetime% > %level_name% > %message% %context% %extra%\n";

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -138,6 +138,11 @@ final class PluginLogger implements ILogger {
         return 'log_transbank_' . $uniqueId . 'log';
     }
 
+    private function getLogFileNameFromCache(): string | bool
+    {
+        return get_transient(self::CACHE_LOG_NAME);
+    }
+
     private function saveLogFileNameInCache(string $logFileName, int $expireTime)
     {
         set_transient(self::CACHE_LOG_NAME, $logFileName, $expireTime);

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -9,7 +9,7 @@ use Transbank\Plugin\Model\LogConfig;
 
 final class PluginLogger implements ILogger {
 
-    const CACHE_LOG_NAME = 'transbank_log_name';
+    const CACHE_LOG_NAME = 'transbank_log_file_name';
 
     private $logger;
     private $config;

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -8,6 +8,9 @@ use Monolog\Formatter\LineFormatter;
 use Transbank\Plugin\Model\LogConfig;
 
 final class PluginLogger implements ILogger {
+    
+    const CACHE_LOG_NAME = 'transbank_log_name';
+    
     private $logger;
     private $config;
 
@@ -22,7 +25,7 @@ final class PluginLogger implements ILogger {
         $this->config = $config;
         $logDir = $this->config->getLogDir();
         $cacheLogName = 'transbank_log_name';
-        $logFile = get_transient($cacheLogName);
+        $logFile = get_transient(self::CACHE_LOG_NAME);
         if (!$logFile) {
             $uniqueId = uniqid('', true);
             $logFile = "{$logDir}/log_transbank_{$uniqueId}.log";

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -122,4 +122,9 @@ final class PluginLogger implements ILogger {
         }
         return $bytes;
     }
+
+    private function getLogFileName(): string {
+        $uniqueId = uniqid('', true);
+        return 'log_transbank_' . $uniqueId . 'log';
+    }
 }

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -43,6 +43,19 @@ final class PluginLogger implements ILogger {
         $this->logger = new Logger('transbank');
         $this->logger->pushHandler($stream);
     }
+    private function getLogFilePath(): string
+    {
+        $logFileName = $this->getLogFileNameFromCache();
+
+        if (!$logFileName) {
+            $logFileName = $this->getLogFileName();
+            $expireTime = strtotime('tomorrow') - time();
+            $this->saveLogFileNameInCache($logFileName, $expireTime);
+        }
+
+        $logDir = $this->getLogDir();
+        return $logDir . $logFileName;
+    }
 
     public function getLogger(){
         return $this->logger;

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -126,7 +126,14 @@ final class PluginLogger implements ILogger {
         return $bytes;
     }
 
-    private function getLogFileName(): string {
+    private function getLogDir(): string
+    {
+        $logDir = $this->config->getLogDir();
+        return trailingslashit($logDir);
+    }
+
+    private function getLogFileName(): string
+    {
         $uniqueId = uniqid('', true);
         return 'log_transbank_' . $uniqueId . 'log';
     }

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -130,4 +130,9 @@ final class PluginLogger implements ILogger {
         $uniqueId = uniqid('', true);
         return 'log_transbank_' . $uniqueId . 'log';
     }
+
+    private function saveLogFileNameInCache(string $logFileName, int $expireTime)
+    {
+        set_transient(self::CACHE_LOG_NAME, $logFileName, $expireTime);
+    }
 }

--- a/plugin/templates/admin/log.php
+++ b/plugin/templates/admin/log.php
@@ -42,12 +42,14 @@ $lineCountTitle = "Cantidad de líneas que posee el último archivo de registro 
                     if (!$folderHasLogs) {
                         $options = "<option value='' selected>No hay archivos log</option>";
                     }
+                    
                     foreach ($resume['logs'] as $index) {
-                        $options .= "<option value='{$index['filename']}'>{$index['filename']}</option>";
-
                         if($index['filename'] == basename($lastLog['filename'])) {
                             $options .= "<option value='{$index['filename']}' selected>{$index['filename']}</option>";
+                            continue;
                         }
+
+                        $options .= "<option value='{$index['filename']}'>{$index['filename']}</option>";
                     }
 
                     echo $options;


### PR DESCRIPTION
This PR saves in cache only the log file name instead of the log file path.

## Test

### Load logs

![image](https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/assets/36648048/b2f8705b-5f97-41a7-9cab-c4f58415dfdc)

