### PR TITLE
feat: use user id instead of the email

### DIFF
--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -717,8 +717,8 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
     private function validatePayerMatchesCardInscription(WC_Payment_Token_Oneclick $paymentToken): bool
     {
         $currentUser = wp_get_current_user();
-        $userEmail = $currentUser->user_email;
-        $inscriptionEmail = $paymentToken->get_email();
+        $userEmail = $currentUser->id;
+        $inscriptionEmail = $paymentToken->get_userId();
 
         return $userEmail == $inscriptionEmail;
     }

--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -717,10 +717,10 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
     private function validatePayerMatchesCardInscription(WC_Payment_Token_Oneclick $paymentToken): bool
     {
         $currentUser = wp_get_current_user();
-        $userEmail = $currentUser->id;
-        $inscriptionEmail = $paymentToken->get_userId();
+        $userId = $currentUser->id;
+        $inscriptionId = $paymentToken->get_userId();
 
-        return $userEmail == $inscriptionEmail;
+        return $userId == $inscriptionId;
     }
 
     public function getOneclickPaymentTokenClass()

--- a/plugin/src/Tokenization/WC_Payment_Token_Oneclick.php
+++ b/plugin/src/Tokenization/WC_Payment_Token_Oneclick.php
@@ -197,4 +197,16 @@ class WC_Payment_Token_Oneclick extends \WC_Payment_Token
     {
         $this->set_prop('email', $email);
     }
+
+    /**
+     * Returns the user id  of the inscriptions.
+     *
+     * @param string $context What the value is for. Valid values are view and edit.
+     *
+     * @return int The user id.
+     */
+    public function get_userId($context = 'view')
+    {
+        return $this->get_prop('user_id', $context);
+    }
 }


### PR DESCRIPTION
This PR refines the Oneclick authorization flow.

## Test

### Authorization Ok
![image](https://github.com/user-attachments/assets/c19be5a9-fe75-48b6-883b-280aab9ee8a1)

### Authorization rejected
![image](https://github.com/user-attachments/assets/1efdc14f-e50c-485a-96e9-e09a8acf8c1d)
