### PR TITLE
feat: set order status on failed subscription payment

### DIFF
--- a/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
+++ b/plugin/src/PaymentGateways/WC_Gateway_Transbank_Oneclick_Mall_REST.php
@@ -187,7 +187,8 @@ class WC_Gateway_Transbank_Oneclick_Mall_REST extends WC_Payment_Gateway_CC
             $this->logger->logInfo('Suscripción autorizada correctamente para la orden #' . $renewalOrder->get_id());
         } catch (Throwable $ex) {
             $this->logger->logError("Error al procesar suscripción: " . $ex->getMessage());
-            $renewalOrder->add_order_note('Error al procesar suscripción, para más detalles revisar el archivo log.');
+            $logsUrl = admin_url('admin.php?page=transbank_webpay_plus_rest&tbk_tab=logs');
+            $this->setOrderAsFailed($renewalOrder, 'Error al procesar suscripción, para más detalles revisar el archivo de <a href=" ' . $logsUrl . '">logs</a>.');
         }
     }
 


### PR DESCRIPTION
This PR set order status when a subscription payment fails.

![image](https://github.com/user-attachments/assets/a5f2bdfb-d7c0-4c42-bd82-5b5900d61f6e)

![image](https://github.com/user-attachments/assets/ff9e9709-69a0-49bc-8857-e210bc4de8d1)

![image](https://github.com/user-attachments/assets/2d4cbc1b-5138-44b1-99cf-53f8bf102667)

![image](https://github.com/user-attachments/assets/1bc6f20b-7039-4f05-a3fc-92fd2b433337)
