### PR TITLE
feat: improve information for transaction status

### DIFF
--- a/plugin/css/tbk.css
+++ b/plugin/css/tbk.css
@@ -1,3 +1,12 @@
+:root {
+    --tbk-red: #D5006C;
+    --tbk-red-2: #C00063;
+    --tbk-success: #28a745;
+    --tbk-info: #007bff;
+    --tbk-warning: #fd7e14;
+    --tbk-error: #dc3545;
+    --tbk-default: #6c757d:
+}
 
 .tbk_table_info {
     width: 600px;
@@ -221,8 +230,6 @@
 }
 
 .tbk-box {
-    --tbk-red: #D5006C;
-    --tbk-red-2: #C00063;
     background: #fff;
     border-radius: 10px;
     padding: 15px;

--- a/plugin/css/tbk.css
+++ b/plugin/css/tbk.css
@@ -420,3 +420,95 @@
     font-size: 18px;
     font-weight: 500;
 }
+
+.tbk-field {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.tbk-field-name {
+    font-weight: bold;
+    margin-right: 8px;
+}
+
+.tbk-field-value {
+    text-align: right;
+    word-break: break-word;
+}
+
+.tbk-badge {
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: bold;
+    color: white
+}
+
+.tbk-badge-success {
+    background-color: var(--tbk-success);
+}
+
+.tbk-badge-info {
+    background-color: var(--tbk-info);
+}
+
+.tbk-badge-warning {
+    background-color: var(--tbk-warning);
+}
+
+.tbk-badge-error {
+    background-color: var(--tbk-error);
+}
+
+.tbk-badge-default {
+    background-color: var(--tbk-default);
+}
+
+.tbk-status {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.tbk-status i {
+    width: 100px;
+    max-width: 24px;
+    text-align: center;
+    font-size: x-large;
+}
+
+.tbk-status p {
+    padding-left: 10px;
+    margin: 0px;
+}
+
+.tbk-status.tbk-status-info i {
+    color: var(--tbk-info);
+}
+
+.tbk-status.tbk-status-error i, .tbk-status.tbk-status-error p {
+    color: var(--tbk-error);
+    font-weight: bold;
+}
+
+.tbk-status-button {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 10px;
+}
+
+.tbk-status-button .tbk-button-primary {
+    width: 100%;
+    text-align: center;
+}
+
+.tbk-separator {
+    width: 100%;
+    height: 1px;
+    background-color: #ccc;
+    margin: 10px 0;
+}

--- a/plugin/js/admin.js
+++ b/plugin/js/admin.js
@@ -13,7 +13,9 @@ jQuery(function($) {
         if ($(`.${btnName}`).data('sending') === true) {
             return false;
         }
-        $(`.${btnName}`).data('sending', true).html(msg);
+        const btn = $(`.${btnName}`);
+        btn.data('sending', true).html(`${msg} <i class="fa fa-spinner fa-spin"></i>`);
+
         e.preventDefault();
         return true;
     }
@@ -72,39 +74,112 @@ jQuery(function($) {
     });
 
     $('.get-transaction-status').on("click",function(e) {
-        if (!blockButton(e, 'get-transaction-status', 'Consultando al API REST...')){
+        e.preventDefault();
+        if (!blockButton(e, 'get-transaction-status', 'Consultando estado')){
             return;
         }
+
+        const container = document.getElementById('transaction_status_admin');
+        container.innerHTML = '';
+
+        const separator = document.createElement('div');
+        separator.className = 'tbk-separator';
+        separator.style.display = 'none';
+        container.appendChild(separator);
+
         post('get_transaction_status', {
             order_id: $('.get-transaction-status').data('order-id'),
             buy_order: $('.get-transaction-status').data('buy-order'),
             token: $('.get-transaction-status').data('token')
         }, (resp) => {
-            let $table = $('.transaction-status-response');
-            let statusData = resp.status;
-            if(resp.product == "webpay_plus"){
-                $("#tbk_wpp_vci").removeClass("tbk-hide");
-                $("#tbk_wpp_session_id").removeClass("tbk-hide");
-            }else{
-                $("#tbk_wpoc_commerce_code").removeClass("tbk-hide");
+            for (const [key, value] of Object.entries(resp)) {
+                const fieldName = document.createElement('span');
+                fieldName.className = 'tbk-field-name';
+                fieldName.textContent = getFieldName(key);
+
+                const fieldValue = document.createElement('span');
+                fieldValue.className = 'tbk-field-value';
+                fieldValue.textContent = value.toString();
+
+                if(key == 'status') {
+                    fieldValue.classList.add('tbk-badge');
+                    fieldValue.classList.add(getBadgeColorFromStatus(value.toString()));
+                }
+
+                if(key == 'cardNumber') {
+                    fieldValue.style.width = '100%';
+                }
+
+                const field = document.createElement('div');
+                field.className = 'tbk-field';
+                field.appendChild(fieldName);
+                field.appendChild(fieldValue);
+
+                container.appendChild(field);
             }
-            const statusDataKeys = Object.keys(statusData);
-            statusDataKeys.forEach(key => {
-                let value = statusData[key] ? statusData[key] : '-';
-                const tableRow = $table.find('.status-' + key);
-                tableRow.html(value);
-            });
-            $table.find('.status-product').html(resp.product);
-            let niceJson = JSON.stringify(resp.raw, null, 2)
-            $table.find('.status-raw').html(`<pre>${niceJson}</pre>`);
-            $table.show();
-            releaseButton('get-transaction-status','Consultar estado de la transacción');
+            separator.style.removeProperty('display');
+
+            releaseButton('get-transaction-status','Consultar Estado');
         }, (error) => {
-            $('.error-status-raw').html(`<p>${error.responseJSON.message}</p>`);
-            $('.error-transaction-status-response').show();
-            releaseButton('get-transaction-status','Consultar estado de la transacción');
+            const errorContainer = createErrorContainer(error.responseJSON.message);
+            container.appendChild(errorContainer);
+            separator.style.removeProperty('display');
+
+            releaseButton('get-transaction-status','Consultar Estado');
         });
     });
+
+    function getBadgeColorFromStatus(status) {
+        const statusColorsDictionary = {
+            'Inicializada': 'tbk-badge-warning',
+            'Capturada': 'tbk-badge-success',
+            'Autorizada': 'tbk-badge-success',
+            'Fallida': 'tbk-badge-error',
+            'Anulada': 'tbk-badge-info',
+            'Parcialmente anulada': 'tbk-badge-info'
+        };
+    
+        return statusColorsDictionary[status] ?? 'tbk-badge-default';
+    }
+
+    function getFieldName(fieldKey) {
+        const fieldNameDictionary = {
+            vci: 'VCI',
+            status: 'Estado',
+            responseCode: 'Código de respuesta',
+            amount: 'Monto',
+            authorizationCode: 'Código de autorización',
+            accountingDate: 'Fecha contable',
+            paymentType: 'Tipo de pago',
+            installmentType: 'Tipo de cuota',
+            installmentNumber: 'Número de cuotas',
+            installmentAmount: 'Monto cuota',
+            sessionId: 'ID de sesión',
+            buyOrder: 'Orden de compra',
+            buyOrderMall: 'Orden de compra mall',
+            buyOrderStore: 'Orden de compra tienda',
+            cardNumber: 'Número de tarjeta',
+            transactionDate: 'Fecha transacción',
+            transactionTime: 'Hora transacción',
+            balance: 'Balance'
+        };
+
+        return fieldNameDictionary[fieldKey] ?? fieldKey;
+    }
+
+    function createErrorContainer(errorMessage)
+    {
+        const errorContainer = document.createElement('div');
+        errorContainer.classList.add('tbk-status', 'tbk-status-error');
+        const icon = document.createElement('i');
+        icon.classList.add('fa', 'fa-times');
+        const paragraph = document.createElement('p');
+        paragraph.textContent = errorMessage;
+
+        errorContainer.appendChild(icon);
+        errorContainer.appendChild(paragraph);
+        return errorContainer;
+    }
 
     $('#mainform').on('click', '.notice-dismiss', function() {
         let noticeId = $(this).closest('.notice').attr('id');
@@ -169,7 +244,4 @@ jQuery(function($) {
 
         });
     });
-
-
-
 })

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -2,6 +2,7 @@
 
 namespace Transbank\WooCommerce\WebpayRest\Controllers;
 
+use Transbank\WooCommerce\WebpayRest\Helpers\ErrorUtil;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkFactory;
 use Transbank\WooCommerce\WebpayRest\Models\Transaction;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkResponseUtil;
@@ -10,7 +11,6 @@ class TransactionStatusController
 {
     const HTTP_OK = 200;
     const HTTP_UNPROCESSABLE_ENTITY = 422;
-    const DEFAULT_ERROR_MESSAGE = 'No se pudo obtener el estado de la transacción';
     const NO_TRANSACTION_ERROR_MESSAGE = 'No hay transacciones webpay aprobadas para esta orden';
     const BUY_ORDER_MISMATCH_ERROR_MESSAGE = 'El buy_order enviado y el buy_order de la transacción no coinciden';
     const TOKEN_MISMATCH_ERROR_MESSAGE = 'El token enviado y el token de la transacción no coinciden';
@@ -18,7 +18,7 @@ class TransactionStatusController
     {
         $response = [
             'body' => [
-                'message' => self::DEFAULT_ERROR_MESSAGE
+                'message' => ErrorUtil::DEFAULT_STATUS_ERROR_MESSAGE
             ]
         ];
         // Check for nonce security

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -53,7 +53,7 @@ class TransactionStatusController
         $token = $this->getSecureInputValue('token');
 
         $requestMethod = $_SERVER['REQUEST_METHOD'];
-        $params = [$orderId, $buyOrder, $token];
+        $params = ['orderId' => $orderId, 'buyOrder' => $buyOrder, 'token' => $token];
 
         $this->logger->logDebug("Request: method -> $requestMethod");
         $this->logger->logDebug('Request: payload -> ' . json_encode($params));

--- a/plugin/src/Helpers/ErrorUtil.php
+++ b/plugin/src/Helpers/ErrorUtil.php
@@ -14,7 +14,7 @@ class ErrorUtil {
 
     const DEFAULT_STATUS_ERROR_MESSAGE = 'Ocurrió un error al tratar de obtener el estado de la transacción.';
     const EXPIRED_TRANSACTION_ERROR_MESSAGE = 'La transacción supera los 7 días y ya no es posible consultarla por este medio.';
-    const API_MISMATCH_ERROR_MESSAGE = 'La version de API es distinta a la utilizada para crear la transacción.';
+    const API_MISMATCH_ERROR_MESSAGE = 'La versión de API es distinta a la utilizada para crear la transacción.';
 
     public static function isApiMismatchError(\Throwable $e)
     {

--- a/plugin/src/Helpers/ErrorUtil.php
+++ b/plugin/src/Helpers/ErrorUtil.php
@@ -12,6 +12,10 @@ class ErrorUtil {
     status 422 => "error_message": "Invalid value for parameter: transaction not found"
     */
 
+    const DEFAULT_STATUS_ERROR_MESSAGE = 'Ocurrió un error al tratar de obtener el estado de la transacción.';
+    const EXPIRED_TRANSACTION_ERROR_MESSAGE = 'La transacción supera los 7 días y ya no es posible consultarla por este medio.';
+    const API_MISMATCH_ERROR_MESSAGE = 'La version de API es distinta a la utilizada para crear la transacción.';
+
     public static function isApiMismatchError(\Throwable $e)
     {
         $error = $e->getMessage();

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -236,4 +236,49 @@ class TbkResponseUtil
         ];
     }
 
+    /**
+     * Get the formatted response for Oneclick status transactions.
+     *
+     * @param object $statusResponse The response object for Oneclick status transactions.
+     * @return array The formatted response fields.
+     */
+    public static function getOneclickStatusFormattedResponse(object $statusResponse): array
+    {
+        $commonFields = self::getCommonFieldsStatusFormatted($statusResponse);
+        $detail = $statusResponse->details[0];
+
+        $status = self::getStatus($detail->status);
+        $amount = self::getAmountFormatted($detail->amount);
+        $paymentType = self::getPaymentType($detail->paymentTypeCode);
+        $installmentType = self::getInstallmentType($detail->paymentTypeCode);
+        $installmentNumber = $detail->installmentsNumber;
+        $installmentAmount = 'N/A';
+        $balance = 'N/A';
+
+        if ($installmentNumber > 0) {
+            $installmentAmount = self::getAmountFormatted($detail->installmentsAmount ?? 0);
+        }
+
+        if (!is_null($detail->balance)) {
+            $balance = self::getAmountFormatted($detail->balance);
+        }
+
+        return [
+            'status' => $status,
+            'responseCode' => $detail->responseCode,
+            'amount' => $amount,
+            'authorizationCode' => $detail->authorizationCode,
+            'accountingDate' => $commonFields['accountingDate'],
+            'paymentType' => $paymentType,
+            'installmentType' => $installmentType,
+            'installmentNumber' => $installmentNumber,
+            'installmentAmount' => $installmentAmount,
+            'buyOrderMall' => $commonFields['buyOrder'],
+            'buyOrderStore' => $detail->buyOrder,
+            'cardNumber' => $commonFields['cardNumber'],
+            'transactionDate' => $commonFields['transactionDate'],
+            'transactionTime' => $commonFields['transactionTime'],
+            'balance' => $balance
+        ];
+    }
 }

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -189,4 +189,51 @@ class TbkResponseUtil
             'accountingDate' => $accountingDate
         ];
     }
+
+    /**
+     * Get the formatted response for Webpay status transactions.
+     *
+     * @param object $statusResponse The response object for Webpay status transactions.
+     * @return array The formatted response fields.
+     */
+    public static function getWebpayStatusFormattedResponse(object $statusResponse): array
+    {
+        $commonFields = self::getCommonFieldsStatusFormatted($statusResponse);
+
+        $status = self::getStatus($statusResponse->status);
+        $amount = self::getAmountFormatted($statusResponse->amount);
+        $paymentType = self::getPaymentType($statusResponse->paymentTypeCode);
+        $installmentType = self::getInstallmentType($statusResponse->paymentTypeCode);
+        $installmentNumber = $statusResponse->installmentsNumber;
+        $installmentAmount = 'N/A';
+        $balance = 'N/A';
+
+        if ($installmentNumber > 0) {
+            $installmentAmount = self::getAmountFormatted($statusResponse->installmentsAmount ?? 0);
+        }
+
+        if (!is_null($statusResponse->balance)) {
+            $balance = self::getAmountFormatted($statusResponse->balance);
+        }
+
+        return [
+            'vci' => $statusResponse->vci,
+            'status' => $status,
+            'responseCode' => $statusResponse->responseCode,
+            'amount' => $amount,
+            'authorizationCode' => $statusResponse->authorizationCode,
+            'accountingDate' => $commonFields['accountingDate'],
+            'paymentType' => $paymentType,
+            'installmentType' => $installmentType,
+            'installmentNumber' => $installmentNumber,
+            'installmentAmount' => $installmentAmount,
+            'sessionId' => $statusResponse->sessionId,
+            'buyOrder' => $commonFields['buyOrder'],
+            'cardNumber' => $commonFields['cardNumber'],
+            'transactionDate' => $commonFields['transactionDate'],
+            'transactionTime' => $commonFields['transactionTime'],
+            'balance' => $balance
+        ];
+    }
+
 }

--- a/plugin/src/Helpers/TbkResponseUtil.php
+++ b/plugin/src/Helpers/TbkResponseUtil.php
@@ -163,4 +163,30 @@ class TbkResponseUtil
 
         return array_merge($commonFields, $oneclickFields);
     }
+
+    /**
+     * Get the common fields formatted for status response.
+     *
+     * @param object $statusResponse The status response.
+     * @return array The formatted common fields for status response.
+     */
+    private static function getCommonFieldsStatusFormatted(object $statusResponse): array
+    {
+        $utcDate = new DateTime($statusResponse->transactionDate, new DateTimeZone('UTC'));
+        $utcDate->setTimeZone(new DateTimeZone(wc_timezone_string()));
+
+        $buyOrder = $statusResponse->buyOrder;
+        $cardNumber = "**** **** **** {$statusResponse->cardNumber}";
+        $transactionDate = $utcDate->format('d-m-Y');
+        $transactionTime = $utcDate->format('H:i:s');
+        $accountingDate = self::getAccountingDate($statusResponse->accountingDate);
+
+        return [
+            'buyOrder' => $buyOrder,
+            'cardNumber' => $cardNumber,
+            'transactionDate' => $transactionDate,
+            'transactionTime' => $transactionTime,
+            'accountingDate' => $accountingDate
+        ];
+    }
 }

--- a/plugin/src/OneclickTransbankSdk.php
+++ b/plugin/src/OneclickTransbankSdk.php
@@ -129,7 +129,7 @@ class OneclickTransbankSdk extends TransbankSdk
             }
 
             if (ErrorUtil::isApiMismatchError($e)) {
-                $errorMessage = ErrorUtil::API_MISMATCH_ERROR_MESSAGE;
+                $errorMessage = ErrorUtil::DEFAULT_STATUS_ERROR_MESSAGE;
             }
 
             $this->errorExecutionTbkApi(

--- a/plugin/src/OneclickTransbankSdk.php
+++ b/plugin/src/OneclickTransbankSdk.php
@@ -122,14 +122,14 @@ class OneclickTransbankSdk extends TransbankSdk
             $this->afterExecutionTbkApi($orderId, 'status', $params, $response);
             return $response;
         } catch (Exception $e) {
-            $errorMessage = 'Ocurrió un error al tratar de obtener el estado de la transacción.';
+            $errorMessage = ErrorUtil::DEFAULT_STATUS_ERROR_MESSAGE;
 
             if(ErrorUtil::isMaxTimeError($e)) {
-                $errorMessage = 'La transacción supera los 7 días y ya no es posible consultarla por este medio.';
+                $errorMessage = ErrorUtil::EXPIRED_TRANSACTION_ERROR_MESSAGE;
             }
 
             if (ErrorUtil::isApiMismatchError($e)) {
-                $errorMessage = 'La version de API es distinta a la utilizada para crear la transacción.';
+                $errorMessage = ErrorUtil::API_MISMATCH_ERROR_MESSAGE;
             }
 
             $this->errorExecutionTbkApi(

--- a/plugin/src/WebpayplusTransbankSdk.php
+++ b/plugin/src/WebpayplusTransbankSdk.php
@@ -98,14 +98,14 @@ class WebpayplusTransbankSdk extends TransbankSdk
             $this->afterExecutionTbkApi($orderId, 'status', $params, $response);
             return $response;
         } catch (Exception $e) {
-            $errorMessage = 'Ocurrió un error al tratar de obtener el estado de la transacción.';
+            $errorMessage = ErrorUtil::DEFAULT_STATUS_ERROR_MESSAGE;
 
-            if (ErrorUtil::isApiMismatchError($e)) {
-                $errorMessage = 'La version de API es distinta a la utilizada para crear la transacción.';
+            if(ErrorUtil::isMaxTimeError($e)) {
+                $errorMessage = ErrorUtil::EXPIRED_TRANSACTION_ERROR_MESSAGE;
             }
 
-            if (ErrorUtil::isMaxTimeError($e)) {
-                $errorMessage = 'La transacción supera los 7 días y ya no es posible consultarla por este medio.';
+            if (ErrorUtil::isApiMismatchError($e)) {
+                $errorMessage = ErrorUtil::API_MISMATCH_ERROR_MESSAGE;
             }
 
             $this->errorExecutionTbkApi(

--- a/plugin/src/WebpayplusTransbankSdk.php
+++ b/plugin/src/WebpayplusTransbankSdk.php
@@ -103,7 +103,7 @@ class WebpayplusTransbankSdk extends TransbankSdk
                 $this->errorExecutionTbkApi($orderId, 'status', $params, 'StatusWebpayException', $e->getMessage(), $errorMessage);
                 throw new StatusWebpayException($errorMessage, $token, $e);
             } elseif (ErrorUtil::isMaxTimeError($e)) {
-                $errorMessage = 'Ya pasaron mas de 7 dias desde la creacion de la transacción, ya no es posible consultarla por este medio';
+                $errorMessage = 'La transacción supera los 7 días y ya no es posible consultarla por este medio.';
                 $this->errorExecutionTbkApi($orderId, 'status', $params, 'StatusWebpayException', $e->getMessage(), $errorMessage);
                 throw new StatusWebpayException($errorMessage, $token, $e);
             }

--- a/plugin/src/WebpayplusTransbankSdk.php
+++ b/plugin/src/WebpayplusTransbankSdk.php
@@ -98,16 +98,16 @@ class WebpayplusTransbankSdk extends TransbankSdk
             $this->afterExecutionTbkApi($orderId, 'status', $params, $response);
             return $response;
         } catch (Exception $e) {
+            $errorMessage = 'Ocurrió un error al tratar de obtener el status ( token: '.$token.') de la transacción Webpay en Transbank: '.$e->getMessage();
+
             if (ErrorUtil::isApiMismatchError($e)) {
                 $errorMessage = 'Esta utilizando una version de api distinta a la utilizada para crear la transacción';
-                $this->errorExecutionTbkApi($orderId, 'status', $params, 'StatusWebpayException', $e->getMessage(), $errorMessage);
-                throw new StatusWebpayException($errorMessage, $token, $e);
-            } elseif (ErrorUtil::isMaxTimeError($e)) {
-                $errorMessage = 'La transacción supera los 7 días y ya no es posible consultarla por este medio.';
-                $this->errorExecutionTbkApi($orderId, 'status', $params, 'StatusWebpayException', $e->getMessage(), $errorMessage);
-                throw new StatusWebpayException($errorMessage, $token, $e);
             }
-            $errorMessage = 'Ocurrió un error al tratar de obtener el status ( token: '.$token.') de la transacción Webpay en Transbank: '.$e->getMessage();
+
+            if (ErrorUtil::isMaxTimeError($e)) {
+                $errorMessage = 'La transacción supera los 7 días y ya no es posible consultarla por este medio.';
+            }
+
             $this->errorExecutionTbkApi($orderId, 'status', $params, 'StatusWebpayException', $e->getMessage(), $errorMessage);
             throw new StatusWebpayException($errorMessage, $token, $e);
         }

--- a/plugin/src/WebpayplusTransbankSdk.php
+++ b/plugin/src/WebpayplusTransbankSdk.php
@@ -105,7 +105,7 @@ class WebpayplusTransbankSdk extends TransbankSdk
             }
 
             if (ErrorUtil::isApiMismatchError($e)) {
-                $errorMessage = ErrorUtil::API_MISMATCH_ERROR_MESSAGE;
+                $errorMessage = ErrorUtil::DEFAULT_STATUS_ERROR_MESSAGE;
             }
 
             $this->errorExecutionTbkApi(

--- a/plugin/src/WebpayplusTransbankSdk.php
+++ b/plugin/src/WebpayplusTransbankSdk.php
@@ -98,17 +98,24 @@ class WebpayplusTransbankSdk extends TransbankSdk
             $this->afterExecutionTbkApi($orderId, 'status', $params, $response);
             return $response;
         } catch (Exception $e) {
-            $errorMessage = 'Ocurrió un error al tratar de obtener el status ( token: '.$token.') de la transacción Webpay en Transbank: '.$e->getMessage();
+            $errorMessage = 'Ocurrió un error al tratar de obtener el estado de la transacción.';
 
             if (ErrorUtil::isApiMismatchError($e)) {
-                $errorMessage = 'Esta utilizando una version de api distinta a la utilizada para crear la transacción';
+                $errorMessage = 'La version de API es distinta a la utilizada para crear la transacción.';
             }
 
             if (ErrorUtil::isMaxTimeError($e)) {
                 $errorMessage = 'La transacción supera los 7 días y ya no es posible consultarla por este medio.';
             }
 
-            $this->errorExecutionTbkApi($orderId, 'status', $params, 'StatusWebpayException', $e->getMessage(), $errorMessage);
+            $this->errorExecutionTbkApi(
+                $orderId,
+                'status',
+                $params,
+                'StatusWebpayException',
+                $e->getMessage(),
+                $errorMessage
+            );
             throw new StatusWebpayException($errorMessage, $token, $e);
         }
     }

--- a/plugin/templates/admin/order/transaction-status.php
+++ b/plugin/templates/admin/order/transaction-status.php
@@ -2,14 +2,13 @@
 if (!defined('ABSPATH')) {
     return;
 }
-if (!$transaction) {
+if (empty($viewData)) {
     echo 'No hay transacciones webpay aprobadas para esta orden';
-
     return;
 }
 ?>
 
-<a class="button action get-transaction-status" data-order-id="<?php echo $order->get_id(); ?>" data-buy-order="<?php echo $transaction->buy_order; ?>" data-token="<?php echo $transaction->token; ?>" href="">Consultar estado de la transacción</a>
+<a class="button action get-transaction-status" data-order-id="<?php echo $viewData['orderId']; ?>" data-buy-order="<?php echo $viewData['buyOrder']; ?>" data-token="<?php echo $viewData['token']; ?>" href="">Consultar estado de la transacción</a>
 
 <p>Esta es la respuesta del API (solo disponible por 7 días desde la fecha de transacción)</p>
 

--- a/plugin/templates/admin/order/transaction-status.php
+++ b/plugin/templates/admin/order/transaction-status.php
@@ -2,84 +2,28 @@
 if (!defined('ABSPATH')) {
     return;
 }
+
+$infoMessage = "El estado de la transacción está disponible solo por 7 días desde su creación.";
+
 if (empty($viewData)) {
-    echo 'No hay transacciones webpay aprobadas para esta orden';
-    return;
+    $infoMessage = 'No hay transacciones Webpay asociadas a esta orden.';
 }
 ?>
 
-<a class="button action get-transaction-status" data-order-id="<?php echo $viewData['orderId']; ?>" data-buy-order="<?php echo $viewData['buyOrder']; ?>" data-token="<?php echo $viewData['token']; ?>" href="">Consultar estado de la transacción</a>
-
-<p>Esta es la respuesta del API (solo disponible por 7 días desde la fecha de transacción)</p>
-
-<div class="transaction-status-response" id="transaction_status_admin" style="display: none">
-    <dl class="transaction-status-response">
-        <dt>Producto:</dt>
-        <dd class="status-product"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Fecha contable:</dt>
-        <dd class="status-accountingDate"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Fecha de transacción:</dt>
-        <dd class="status-transactionDate"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Estado:</dt>
-        <dd class="status-status"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Monto de la transacción:</dt>
-        <dd class="status-amount"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Balance:</dt>
-        <dd class="status-balance"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Código de autorización:</dt>
-        <dd class="status-authorizationCode"></dd>
-    </dl>
-    <dl class="transaction-status-response tbk-hide" id="tbk_wpp_vci">
-        <dt>VCI:</dt>
-        <dd class="status-vci"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Orden de compra:</dt>
-        <dd class="status-buyOrder"></dd>
-    </dl>
-    <dl class="transaction-status-response tbk-hide" id="tbk_wpoc_commerce_code">
-        <dt>Código de comercio:</dt>
-        <dd class="status-commerceCode"></dd>
-    </dl>
-    <dl class="transaction-status-response tbk-hide" id="tbk_wpp_session_id">
-        <dt>ID Sesión:</dt>
-        <dd class="status-sessionId"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Tipo de pago:</dt>
-        <dd class="status-paymentTypeCode"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Código de respuesta:</dt>
-        <dd class="status-responseCode"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Número de cuotas:</dt>
-        <dd class="status-installmentsNumber"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt>Monto de cada cuota:</dt>
-        <dd class="status-installmentsAmount"></dd>
-    </dl>
-    <dl class="transaction-status-response">
-        <dt >Respuesta Completa:</dt>
-        <dd class="status-raw"></dd>
-    </dl>
+<div class="tbk-status-button">
+    <a class="button tbk-button-primary get-transaction-status"
+    data-order-id="<?php echo $viewData['orderId']; ?>"
+    data-buy-order="<?php echo $viewData['buyOrder']; ?>"
+    data-token="<?php echo $viewData['token']; ?>"
+    href="#">
+        Consultar Estado
+    </a>
 </div>
 
-<div class="error-transaction-status-response" style="display: none">
-    <div>Error consultando estado de la transacción</div>
-    <div class="error-status-raw"></div>
+<div class="tbk-status tbk-status-info">
+    <i class="fa fa-info-circle"></i>
+    <p><?= $infoMessage ?></p>
+</div>
+
+<div id="transaction_status_admin">
 </div>

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -45,10 +45,11 @@ $hposHelper = new HposHelper();
 $hposExists = $hposHelper->checkIfHposExists();
 
 add_action('plugins_loaded', 'registerPaymentGateways', 0);
-add_action('wp_loaded', function () use ($hposExists) {
-    woocommerceTransbankInit($hposExists);
-});
+add_action('wp_loaded', 'woocommerceTransbankInit');
 add_action('admin_init', 'on_transbank_rest_webpay_plugins_loaded');
+add_action('add_meta_boxes', function () use ($hposExists) {
+    addTransbankStatusMetaBox($hposExists);
+});
 
 add_action('init', function() {
     add_action('wp_ajax_check_connection', ConnectionCheck::class . '::check');
@@ -113,7 +114,7 @@ add_action('init', function () {
     }
 });
 
-function woocommerceTransbankInit(bool $hposExists)
+function woocommerceTransbankInit()
 {
     if (!class_exists('WC_Payment_Gateway')) {
         noticeMissingWoocommerce();
@@ -122,7 +123,6 @@ function woocommerceTransbankInit(bool $hposExists)
 
     registerAdminMenu();
     registerPluginActionLinks();
-    registerMetaBoxes($hposExists);
     NoticeHelper::registerNoticesDismissHook();
     NoticeHelper::handleReviewNotice();
 }
@@ -174,13 +174,6 @@ function registerPluginActionLinks()
         ];
 
         return array_merge($actionLinks, $newLinks);
-    });
-}
-
-function registerMetaBoxes(bool $hPosExists)
-{
-    add_action('add_meta_boxes', function () use ($hPosExists) {
-        addTransbankStatusMetaBox($hPosExists);
     });
 }
 

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -50,10 +50,13 @@ add_action('wp_loaded', function () use ($hposExists) {
 });
 add_action('admin_init', 'on_transbank_rest_webpay_plugins_loaded');
 
-add_action('wp_ajax_check_connection', ConnectionCheck::class . '::check');
-add_action('wp_ajax_check_exist_tables', TableCheck::class . '::check');
-add_action('wp_ajax_check_can_download_file', PluginLogger::class . '::checkCanDownloadLogFile');
-add_action('wp_ajax_get_transaction_status', [new TransactionStatusController(), 'getStatus']);
+add_action('init', function() {
+    add_action('wp_ajax_check_connection', ConnectionCheck::class . '::check');
+    add_action('wp_ajax_check_exist_tables', TableCheck::class . '::check');
+    add_action('wp_ajax_check_can_download_file', PluginLogger::class . '::checkCanDownloadLogFile');
+    add_action('wp_ajax_get_transaction_status', [new TransactionStatusController(), 'getStatus']);
+});
+
 add_action('woocommerce_before_cart', 'transbank_rest_before_cart');
 
 add_action('woocommerce_before_checkout_form', 'transbank_rest_check_cancelled_checkout');

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -1,4 +1,5 @@
 <?php
+
 use Transbank\WooCommerce\WebpayRest\Controllers\TransactionStatusController;
 use Transbank\WooCommerce\WebpayRest\Helpers\DatabaseTableInstaller;
 use Transbank\WooCommerce\WebpayRest\Helpers\SessionMessageHelper;
@@ -12,6 +13,8 @@ use Transbank\WooCommerce\WebpayRest\Blocks\WCGatewayTransbankOneclickBlocks;
 use Transbank\WooCommerce\WebpayRest\Utils\ConnectionCheck;
 use Transbank\WooCommerce\WebpayRest\Utils\TableCheck;
 use Transbank\Plugin\Helpers\PluginLogger;
+use Transbank\WooCommerce\WebpayRest\Utils\Template;
+use Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController;
 
 if (!defined('ABSPATH')) {
     return;
@@ -36,10 +39,15 @@ if (!defined('ABSPATH')) {
  * WC tested up to: 8.9.1
  */
 
-require_once plugin_dir_path(__FILE__).'vendor/autoload.php';
+require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
+
+$hposHelper = new HposHelper();
+$hposExists = $hposHelper->checkIfHposExists();
 
 add_action('plugins_loaded', 'registerPaymentGateways', 0);
-add_action('wp_loaded', 'woocommerceTransbankInit');
+add_action('wp_loaded', function () use ($hposExists) {
+    woocommerceTransbankInit($hposExists);
+});
 add_action('admin_init', 'on_transbank_rest_webpay_plugins_loaded');
 
 add_action('wp_ajax_check_connection', ConnectionCheck::class . '::check');
@@ -60,36 +68,34 @@ add_action('admin_enqueue_scripts', function () {
     ]);
 });
 
-add_action('woocommerce_blocks_loaded', function() {
-    if ( class_exists( 'Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType' ) ){
+add_action('woocommerce_blocks_loaded', function () {
+    if (class_exists('Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType')) {
         require_once 'src/Blocks/WC_Gateway_Transbank_Webpay_Blocks.php';
         require_once 'src/Blocks/WC_Gateway_Transbank_Oneclick_Blocks.php';
         add_action(
             'woocommerce_blocks_payment_method_type_registration',
-            function( Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry ) {
-                $payment_method_registry->register( new WCGatewayTransbankWebpayBlocks() );
-                $payment_method_registry->register( new WCGatewayTransbankOneclickBlocks() );
+            function (Automattic\WooCommerce\Blocks\Payments\PaymentMethodRegistry $payment_method_registry) {
+                $payment_method_registry->register(new WCGatewayTransbankWebpayBlocks());
+                $payment_method_registry->register(new WCGatewayTransbankOneclickBlocks());
             }
         );
     }
 });
 
-add_action( 'before_woocommerce_init', function() {
-    if ( class_exists( '\Automattic\WooCommerce\Utilities\FeaturesUtil' ) ) {
-        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'cart_checkout_blocks', __FILE__, true );
+add_action('before_woocommerce_init', function () {
+    if (class_exists('\Automattic\WooCommerce\Utilities\FeaturesUtil')) {
+        \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility('cart_checkout_blocks', __FILE__, true);
     }
-} );
+});
 
-$hposHelper = new HposHelper();
-$hPosExists = $hposHelper->checkIfHposExists();
-if ($hPosExists)
-{
+if ($hposExists) {
     add_action('before_woocommerce_init', function () {
-        if (class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
+        if (class_exists(\Automattic\WooCommerce\Utilities\FeaturesUtil::class)) {
             \Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
                 'custom_order_tables',
                 __FILE__,
-                true);
+                true
+            );
         }
     });
 }
@@ -104,26 +110,31 @@ add_action('init', function () {
     }
 });
 
-function woocommerceTransbankInit() {
+function woocommerceTransbankInit(bool $hposExists)
+{
     if (!class_exists('WC_Payment_Gateway')) {
         noticeMissingWoocommerce();
         return;
     }
+
     registerAdminMenu();
     registerPluginActionLinks();
+    registerMetaBoxes($hposExists);
     NoticeHelper::registerNoticesDismissHook();
     NoticeHelper::handleReviewNotice();
 }
 
-function registerPaymentGateways() {
-    add_filter('woocommerce_payment_gateways', function($methods) {
+function registerPaymentGateways()
+{
+    add_filter('woocommerce_payment_gateways', function ($methods) {
         $methods[] = WC_Gateway_Transbank_Webpay_Plus_REST::class;
         $methods[] = WC_Gateway_Transbank_Oneclick_Mall_REST::class;
         return $methods;
     });
 }
 
-function registerAdminMenu() {
+function registerAdminMenu()
+{
     add_action('admin_menu', function () {
         add_submenu_page('woocommerce', __('Configuración de Webpay Plus', 'transbank_wc_plugin'), 'Webpay Plus', 'administrator', 'transbank_webpay_plus_rest', function () {
             $tab = filter_input(INPUT_GET, 'tbk_tab', FILTER_DEFAULT);
@@ -132,7 +143,7 @@ function registerAdminMenu() {
                 wp_redirect(admin_url('admin.php?page=wc-settings&tab=checkout&section=transbank_webpay_plus_rest&tbk_tab=options'));
             }
 
-            include_once __DIR__.'/views/admin/options-tabs.php';
+            include_once __DIR__ . '/views/admin/options-tabs.php';
         }, null);
 
         add_submenu_page('woocommerce', __('Configuración de Webpay Plus', 'transbank_wc_plugin'), 'Webpay Oneclick', 'administrator', 'transbank_webpay_oneclick_rest', function () {
@@ -141,8 +152,9 @@ function registerAdminMenu() {
     });
 }
 
-function registerPluginActionLinks() {
-    add_filter('plugin_action_links_'.plugin_basename(__FILE__), function ($actionLinks) {
+function registerPluginActionLinks()
+{
+    add_filter('plugin_action_links_' . plugin_basename(__FILE__), function ($actionLinks) {
         $webpaySettingsLink = sprintf(
             '<a href="%s">%s</a>',
             admin_url('admin.php?page=wc-settings&tab=checkout&section=transbank_webpay_plus_rest'),
@@ -162,6 +174,64 @@ function registerPluginActionLinks() {
     });
 }
 
+function registerMetaBoxes(bool $hPosExists)
+{
+    add_action('add_meta_boxes', function () use ($hPosExists) {
+        addTransbankStatusMetaBox($hPosExists);
+    });
+}
+
+function addTransbankStatusMetaBox(bool $hPosExists)
+{
+    if ($hPosExists) {
+        $screen = wc_get_container()
+            ->get(CustomOrdersTableController::class)
+            ->custom_orders_table_usage_is_enabled()
+            ? wc_get_page_screen_id('shop-order')
+            : 'shop_order';
+
+        add_meta_box(
+            'transbank_check_payment_status',
+            __('Verificar estado del pago', 'transbank_wc_plugin'),
+            function ($post_or_order_object) {
+                $order = ($post_or_order_object instanceof WP_Post)
+                    ? wc_get_order($post_or_order_object->ID)
+                    : $post_or_order_object;
+
+                $orderId = $order->get_id();
+                renderTransactionStatusMetaBox($orderId);
+            },
+            $screen,
+            'side',
+            'core'
+        );
+    } else {
+        add_meta_box('transbank_check_payment_status', __('Verificar estado del pago', 'transbank_wc_plugin'), function ($post) {
+            $order = new WC_Order($post->ID);
+            $orderId = $order->get_id();
+            renderTransactionStatusMetaBox($orderId);
+        }, 'shop_order', 'side', 'core');
+    }
+}
+
+function renderTransactionStatusMetaBox(int $orderId)
+{
+    $viewData = [];
+    $transaction = Transaction::getApprovedByOrderId($orderId);
+
+    if ($transaction) {
+        $viewData = [
+            'viewData' => [
+                'orderId' => $orderId,
+                'token' => $transaction->token,
+                'buyOrder' => $transaction->buy_order
+            ]
+        ];
+    }
+
+    (new Template())->render('admin/order/transaction-status.php', $viewData);
+}
+
 function on_transbank_rest_webpay_plugins_loaded()
 {
     DatabaseTableInstaller::createTableIfNeeded();
@@ -174,39 +244,7 @@ function transbank_rest_remove_database()
 
 register_uninstall_hook(__FILE__, 'transbank_rest_remove_database');
 
-if ($hPosExists)
-{
-    add_action('add_meta_boxes', function () {
-        $screen = wc_get_container()
-            ->get(Automattic\WooCommerce\Internal\DataStores\Orders\CustomOrdersTableController::class)
-            ->custom_orders_table_usage_is_enabled()
-            ? wc_get_page_screen_id('shop-order')
-            : 'shop_order';
-        add_meta_box(
-            'transbank_check_payment_status',
-            __('Verificar estado del pago', 'transbank_wc_plugin'),
-            function ($post_or_order_object) {
-                $order = ($post_or_order_object instanceof WP_Post)
-                ? wc_get_order($post_or_order_object->ID)
-                : $post_or_order_object;
-                $transaction = Transaction::getApprovedByOrderId($order->get_id());
-                include_once __DIR__.'/views/get-status.php';
-            },
-            $screen,
-            'side',
-            'core');
-    });
-}
-else
-{
-    add_action('add_meta_boxes', function () {
-        add_meta_box('transbank_check_payment_status', __('Verificar estado del pago', 'transbank_wc_plugin'), function ($post) {
-            $order = new WC_Order($post->ID);
-            $transaction = Transaction::getApprovedByOrderId($order->get_id());
-            include_once __DIR__.'/views/get-status.php';
-        }, 'shop_order', 'side', 'core');
-    });
-}
+
 
 function transbank_rest_before_cart()
 {
@@ -225,7 +263,8 @@ function transbank_rest_check_cancelled_checkout()
     }
 }
 
-function noticeMissingWoocommerce() {
+function noticeMissingWoocommerce()
+{
     add_action(
         'admin_notices',
         function () {
@@ -253,7 +292,7 @@ function noticeMissingWoocommerce() {
                 $isWooInstalled = !empty($allPlugins['woocommerce/woocommerce.php']);
             }
 
-            if(function_exists('is_plugin_active')) {
+            if (function_exists('is_plugin_active')) {
                 $isWooActivated = is_plugin_active('woocommerce/woocommerce.php');
             }
 
@@ -272,7 +311,7 @@ function noticeMissingWoocommerce() {
                 $noticeDescription = "Woocommerce no se encuentra activado.";
             }
 
-            include_once plugin_dir_path(__FILE__) .'views/admin/components/notice-missing-woocommerce.php';
+            include_once plugin_dir_path(__FILE__) . 'views/admin/components/notice-missing-woocommerce.php';
         }
     );
 }


### PR DESCRIPTION
This PR improves the way transaction status data is displayed. The detail is:

- Improve messages to users.
- Add formatting to fields.
- Add logs to the controller to obtain the status of the transaction.
- Improves error control.

Note: 
The colors in the status were added so that the transaction can always be consulted in the future, if possible, not only when it is approved.

## Tests

### Authorized transaction
![image](https://github.com/user-attachments/assets/200c2994-243e-4fd8-b5aa-0cc7488b8556)

### Refunded transaction
![image](https://github.com/user-attachments/assets/57f9a10f-f723-485f-9bb4-3d9307303303)![image](https://github.com/user-attachments/assets/c94fdc60-2208-4512-a82a-6448ebac9a6e)

### Error getting status
![image](https://github.com/user-attachments/assets/d80f39d9-92ef-436d-947e-c77b3cf586c7)![image](https://github.com/user-attachments/assets/f432c3bd-e47c-4213-a285-984cd79c47dc)
