### PR TITLE
feat: add color class for reversed state

### DIFF
--- a/plugin/js/admin.js
+++ b/plugin/js/admin.js
@@ -136,6 +136,7 @@ jQuery(function($) {
             'Autorizada': 'tbk-badge-success',
             'Fallida': 'tbk-badge-error',
             'Anulada': 'tbk-badge-info',
+            'Reversada': 'tbk-badge-info',
             'Parcialmente anulada': 'tbk-badge-info'
         };
     


### PR DESCRIPTION
This PR add a color class for the reversed state in the status meta box.

## Test

### State Reversed
![image](https://github.com/user-attachments/assets/0c9697cc-0a9b-4f8b-8e63-2ad1e9358668)

