### PR TITLE
fix: show meta box status when no transaction found

### DIFF
--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -62,6 +62,7 @@ class TransactionStatusController
             $transaction = Transaction::getApprovedByOrderId($orderId);
 
             if (!$transaction) {
+                $response['body']['message'] = self::NO_TRANSACTION_ERROR_MESSAGE;
                 $response['body'] = self::NO_TRANSACTION_ERROR_MESSAGE;
                 wp_send_json($response['body'], self::HTTP_UNPROCESSABLE_ENTITY);
                 return;

--- a/plugin/templates/admin/order/transaction-status.php
+++ b/plugin/templates/admin/order/transaction-status.php
@@ -11,6 +11,7 @@ if (empty($viewData)) {
 ?>
 
 <div class="tbk-status-button">
+<?php if (!empty($viewData)): ?>
     <a class="button tbk-button-primary get-transaction-status"
     data-order-id="<?php echo $viewData['orderId']; ?>"
     data-buy-order="<?php echo $viewData['buyOrder']; ?>"
@@ -18,6 +19,7 @@ if (empty($viewData)) {
     href="#">
         Consultar Estado
     </a>
+<?php endif; ?>
 </div>
 
 <div class="tbk-status tbk-status-info">


### PR DESCRIPTION
This PR resolves an issue where the "Check Status" button was displayed even when no Webpay transaction was present.

## Test

### No transaction
![Captura de pantalla 2024-11-22 a la(s) 10 46 50 a  m](https://github.com/user-attachments/assets/9bc0fa00-18a3-4aef-aafc-c602cbb50318)

### Transaction present
![Captura de pantalla 2024-11-22 a la(s) 10 47 09 a  m](https://github.com/user-attachments/assets/c4c00196-a72d-4535-a31e-491538e645ec)

### Get status
![image](https://github.com/user-attachments/assets/ed2071f2-0262-4f79-8fd6-155bab1c4fb9)
