### PR TITLE
refactor: rename test connection method

### DIFF
--- a/plugin/src/Utils/ConnectionCheck.php
+++ b/plugin/src/Utils/ConnectionCheck.php
@@ -7,7 +7,7 @@ class ConnectionCheck
 {
     public static function check()
     {
-        $resp = ConnectionCheck::setCreateTransaction();
+        $resp = ConnectionCheck::performTestTransaction();
 
         header('Content-Type: application/json');
         ob_clean();
@@ -15,7 +15,7 @@ class ConnectionCheck
         wp_die();
     }
 
-    public static function setCreateTransaction()
+    public static function performTestTransaction()
     {
         $amount = 990;
         $buyOrder = '_Healthcheck_';


### PR DESCRIPTION
This PR rename the test connection method to improve legilibility.

## Tests

### Test Connection Ok
![image](https://github.com/user-attachments/assets/428202db-f801-4740-a1e9-c44ced4df95e)
