### PR TITLE
feat: get status for all orders

### DIFF
--- a/plugin/css/tbk.css
+++ b/plugin/css/tbk.css
@@ -5,7 +5,7 @@
     --tbk-info: #007bff;
     --tbk-warning: #fd7e14;
     --tbk-error: #dc3545;
-    --tbk-default: #6c757d:
+    --tbk-default: #6c757d;
 }
 
 .tbk_table_info {

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -11,9 +11,9 @@ class TransactionStatusController
 {
     const HTTP_OK = 200;
     const HTTP_UNPROCESSABLE_ENTITY = 422;
-    const NO_TRANSACTION_ERROR_MESSAGE = 'No hay transacciones webpay aprobadas para esta orden';
-    const BUY_ORDER_MISMATCH_ERROR_MESSAGE = 'El buy_order enviado y el buy_order de la transacción no coinciden';
-    const TOKEN_MISMATCH_ERROR_MESSAGE = 'El token enviado y el token de la transacción no coinciden';
+    const NO_TRANSACTION_ERROR_MESSAGE = 'No hay transacciones webpay aprobadas para esta order.';
+    const BUY_ORDER_MISMATCH_ERROR_MESSAGE = 'El buy_order enviado y el buy_order de la transacción no coinciden.';
+    const TOKEN_MISMATCH_ERROR_MESSAGE = 'El token enviado y el token de la transacción no coinciden.';
 
     /**
      * Log instance.

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -63,17 +63,19 @@ class TransactionStatusController
             $transaction = Transaction::getApprovedByOrderId($orderId);
 
             if (!$transaction) {
+                $this->logger->logError(self::NO_TRANSACTION_ERROR_MESSAGE);
                 $response['body']['message'] = self::NO_TRANSACTION_ERROR_MESSAGE;
                 $response['body'] = self::NO_TRANSACTION_ERROR_MESSAGE;
                 wp_send_json($response['body'], self::HTTP_UNPROCESSABLE_ENTITY);
                 return;
             }
 
+            $this->logger->logInfo('Transacción encontrada.');
             $response = $this->handleGetStatus($transaction, $orderId, $buyOrder, $token);
 
             wp_send_json($response['body'], $response['code']);
         } catch (\Exception $e) {
-            wp_send_json([
+            $this->logger->logError($e->getMessage());
                 'message' => $e->getMessage(),
             ], 422);
         }

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -65,7 +65,6 @@ class TransactionStatusController
             if (!$transaction) {
                 $this->logger->logError(self::NO_TRANSACTION_ERROR_MESSAGE);
                 $response['body']['message'] = self::NO_TRANSACTION_ERROR_MESSAGE;
-                $response['body'] = self::NO_TRANSACTION_ERROR_MESSAGE;
                 wp_send_json($response['body'], self::HTTP_UNPROCESSABLE_ENTITY);
                 return;
             }

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -60,7 +60,7 @@ class TransactionStatusController
         $this->logger->logDebug('Request: payload -> ' . json_encode($params));
 
         try {
-            $transaction = Transaction::getApprovedByOrderId($orderId);
+            $transaction = Transaction::getByOrderId($orderId);
 
             if (!$transaction) {
                 $this->logger->logError(self::NO_TRANSACTION_ERROR_MESSAGE);

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -14,6 +14,7 @@ class TransactionStatusController
     const NO_TRANSACTION_ERROR_MESSAGE = 'No hay transacciones webpay aprobadas para esta orden';
     const BUY_ORDER_MISMATCH_ERROR_MESSAGE = 'El buy_order enviado y el buy_order de la transacción no coinciden';
     const TOKEN_MISMATCH_ERROR_MESSAGE = 'El token enviado y el token de la transacción no coinciden';
+    const EXCEPTION_MESSAGE = 'Ha ocurrido un error al obtener el estado de la transacción.';
 
     /**
      * Log instance.

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -74,7 +74,7 @@ class TransactionStatusController
             $response = $this->handleGetStatus($transaction, $orderId, $buyOrder, $token);
 
             wp_send_json($response['body'], $response['code']);
-        } catch (\Exception $e) {
+        } catch (\Throwable $e) {
             $this->logger->logError($e->getMessage());
                 'message' => $e->getMessage(),
             ], 422);

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -76,8 +76,8 @@ class TransactionStatusController
             wp_send_json($response['body'], $response['code']);
         } catch (\Throwable $e) {
             $this->logger->logError($e->getMessage());
-                'message' => $e->getMessage(),
-            ], 422);
+            $response['body']['message'] = $e->getMessage();
+            wp_send_json($response['body'], self::HTTP_UNPROCESSABLE_ENTITY);
         }
     }
 

--- a/plugin/src/Controllers/TransactionStatusController.php
+++ b/plugin/src/Controllers/TransactionStatusController.php
@@ -14,7 +14,6 @@ class TransactionStatusController
     const NO_TRANSACTION_ERROR_MESSAGE = 'No hay transacciones webpay aprobadas para esta orden';
     const BUY_ORDER_MISMATCH_ERROR_MESSAGE = 'El buy_order enviado y el buy_order de la transacción no coinciden';
     const TOKEN_MISMATCH_ERROR_MESSAGE = 'El token enviado y el token de la transacción no coinciden';
-    const EXCEPTION_MESSAGE = 'Ha ocurrido un error al obtener el estado de la transacción.';
 
     /**
      * Log instance.

--- a/plugin/src/Models/Transaction.php
+++ b/plugin/src/Models/Transaction.php
@@ -21,11 +21,13 @@ class Transaction extends BaseModel
     /**
      * Get transactions by custom conditions.
      *
-     * @param array $conditions Key-value pairs of column names and values.
+     * @param array $conditions         Key-value pairs of column names and values.
+     * @param string|string[] $orderBy  Column name or an array of column names to order by.
+     * @param string $orderDirection    Order direction ('ASC' or 'DESC').
      *
-     * @return array|null Transaction data.
+     * @return array|null Transaction objects array.
      */
-    private static function getTransactionsByConditions(array $conditions): ?array
+    private static function getTransactionsByConditions(array $conditions, string $orderBy = '', string $orderDirection = 'DESC'): ?array
     {
         global $wpdb;
         $tableName = static::getTableName();
@@ -37,6 +39,17 @@ class Transaction extends BaseModel
 
         $whereSql = implode(' AND ', $whereClauses);
         $sql = "SELECT * FROM {$tableName} WHERE {$whereSql}";
+
+        if (!empty($orderBy)) {
+            if (is_array($orderBy)) {
+                $orderBy = implode(", ", array_map('esc_sql', $orderBy));
+            } else {
+                $orderBy = esc_sql($orderBy);
+            }
+            $orderDirection = strtoupper($orderDirection) === 'DESC' ? 'DESC' : 'ASC';
+            $sql .= " ORDER BY {$orderBy} {$orderDirection}";
+        }
+
         return $wpdb->get_results($sql);
     }
 
@@ -49,7 +62,7 @@ class Transaction extends BaseModel
      */
     public static function getByOrderId($orderId): ?object
     {
-        return static::getTransactionsByConditions(['order_id' => $orderId])[0] ?? null;
+        return static::getTransactionsByConditions(['order_id' => $orderId], 'id')[0] ?? null;
     }
 
     /**

--- a/plugin/src/Models/Transaction.php
+++ b/plugin/src/Models/Transaction.php
@@ -19,6 +19,40 @@ class Transaction extends BaseModel
     const PRODUCT_WEBPAY_ONECLICK = 'webpay_oneclick';
 
     /**
+     * Get transactions by custom conditions.
+     *
+     * @param array $conditions Key-value pairs of column names and values.
+     *
+     * @return array|null Transaction data.
+     */
+    private static function getTransactionsByConditions(array $conditions): ?array
+    {
+        global $wpdb;
+        $tableName = static::getTableName();
+
+        $whereClauses = [];
+        foreach ($conditions as $column => $value) {
+            $whereClauses[] = $wpdb->prepare("`$column` = %s", $value);
+        }
+
+        $whereSql = implode(' AND ', $whereClauses);
+        $sql = "SELECT * FROM {$tableName} WHERE {$whereSql}";
+        return $wpdb->get_results($sql);
+    }
+
+    /**
+     * Get transaction by order ID.
+     *
+     * @param string $orderId Order ID.
+     *
+     * @return object|null Transaction data.
+     */
+    public static function getByOrderId($orderId): ?object
+    {
+        return static::getTransactionsByConditions(['order_id' => $orderId])[0] ?? null;
+    }
+
+    /**
      * @return string
      */
     public static function getTableName(): string

--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -51,7 +51,7 @@ add_action('add_meta_boxes', function () use ($hposExists) {
     addTransbankStatusMetaBox($hposExists);
 });
 
-add_action('init', function() {
+add_action('init', function () {
     add_action('wp_ajax_check_connection', ConnectionCheck::class . '::check');
     add_action('wp_ajax_check_exist_tables', TableCheck::class . '::check');
     add_action('wp_ajax_check_can_download_file', PluginLogger::class . '::checkCanDownloadLogFile');
@@ -68,7 +68,7 @@ add_action('admin_enqueue_scripts', function () {
     wp_enqueue_script('tbk-thickbox', plugins_url('/js/swal.min.js', __FILE__));
     wp_localize_script('tbk-ajax-script', 'ajax_object', [
         'ajax_url' => admin_url('admin-ajax.php'),
-        'nonce'    => wp_create_nonce('my-ajax-nonce'),
+        'nonce' => wp_create_nonce('my-ajax-nonce'),
     ]);
 });
 
@@ -213,7 +213,7 @@ function addTransbankStatusMetaBox(bool $hPosExists)
 function renderTransactionStatusMetaBox(int $orderId)
 {
     $viewData = [];
-    $transaction = Transaction::getApprovedByOrderId($orderId);
+    $transaction = Transaction::getByOrderId($orderId);
 
     if ($transaction) {
         $viewData = [
@@ -284,7 +284,7 @@ function noticeMissingWoocommerce()
             );
 
             if (function_exists('get_plugins')) {
-                $allPlugins  = get_plugins();
+                $allPlugins = get_plugins();
                 $isWooInstalled = !empty($allPlugins['woocommerce/woocommerce.php']);
             }
 


### PR DESCRIPTION
This PR add the function to get status for all orders. Not only for approved orders.

## Tests

### Error in API.
![image](https://github.com/user-attachments/assets/a4ca1d50-26ef-4575-95c1-7e8942e2e30c)

### No transaction
![image](https://github.com/user-attachments/assets/ec169ceb-45df-4fad-ad65-0f883c3dfc4f)

### Expired to get status
![image](https://github.com/user-attachments/assets/a7e67eb0-2077-4f2a-89be-e266ab52d83c)

### Get status not approved transaction
![image](https://github.com/user-attachments/assets/fc2776ac-7afe-4da3-ac97-349a042fe06f)

### Get transaction approved transaction
![image](https://github.com/user-attachments/assets/c36662bc-4ece-463f-90f0-f9723844e8d8)

