### PR TITLE
fix: deprecated warning message

### DIFF
--- a/plugin/webpay-rest.php
+++ b/plugin/webpay-rest.php
@@ -140,7 +140,7 @@ function registerAdminMenu()
 {
     add_action('admin_menu', function () {
         add_submenu_page('woocommerce', __('Configuración de Webpay Plus', 'transbank_wc_plugin'), 'Webpay Plus', 'administrator', 'transbank_webpay_plus_rest', function () {
-            $tab = filter_input(INPUT_GET, 'tbk_tab', FILTER_DEFAULT);
+            $tab = filter_input(INPUT_GET, 'tbk_tab', FILTER_DEFAULT) ?? '';
             $tab = htmlspecialchars($tab, ENT_QUOTES, 'UTF-8');
             if (!in_array($tab, ['healthcheck', 'logs', 'transactions'])) {
                 wp_redirect(admin_url('admin.php?page=wc-settings&tab=checkout&section=transbank_webpay_plus_rest&tbk_tab=options'));


### PR DESCRIPTION
This PR remove a deprecated message from ecommerce site when use the Webpay Plus config options in WooCommerce menu.

## Test
### Webpay config
![image](https://github.com/user-attachments/assets/b79733d6-d24c-4262-95bf-86448bd34d1b)

### Oneclick config
![image](https://github.com/user-attachments/assets/e12326cc-10d1-4428-b3d7-9bf3f8307c33)

### Transactions
![image](https://github.com/user-attachments/assets/49a0aad7-1d64-4f59-a239-00aa2c60bd3d)

### Healtcheck
![image](https://github.com/user-attachments/assets/ef362e58-9d2d-4a01-89d1-33351eb7824b)

### Logs
![image](https://github.com/user-attachments/assets/c05770c1-1bc0-4138-8b70-145e2972f70b)
