### PR TITLE
fix: remove transaction sort option from admin transaction table

### DIFF
--- a/plugin/src/Helpers/WebpayTransactionsTable.php
+++ b/plugin/src/Helpers/WebpayTransactionsTable.php
@@ -47,8 +47,7 @@ class WebpayTransactionsTable extends WP_List_Table
             'order_id' => ['order_id', false],
             'product' => ['product', false],
             'status' => ['status', false],
-            'environment' => ['environment', false],
-            'transaction_date' => ['transaction_date', false],
+            'environment' => ['environment', false]
         ];
     }
 


### PR DESCRIPTION
This PR removes the transaction sort option from the admin transaction table.

The sorting option was causing inconsistent behavior when ordering transactions, leading to empty results or requiring a page refresh to restore the table view. To prevent confusion and improve stability in the admin interface, the sort option has been removed.

**Tests**
Before
<img width="1200" height="511" alt="image" src="https://github.com/user-attachments/assets/262f7691-ccff-4d6a-ac34-9225301d4d34" />


After
<img width="929" height="554" alt="image" src="https://github.com/user-attachments/assets/da528546-13c2-4a29-9301-34f9c5183329" />
