### PR TITLE
TBK-207 feat: refine scoped autoload flow

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -208,6 +208,8 @@ validate_scoped_autoload_maps() {
             fi
         done
     done
+
+    return 0
 }
 
 validate_packaging_layout() {

--- a/package.sh
+++ b/package.sh
@@ -9,6 +9,7 @@ PLUGIN_FILE="transbank-webpay-plus-rest.zip"
 MAIN_FILE="webpay-rest.php"
 README_FILE="readme.txt"
 ENABLE_SCOPER="${ENABLE_SCOPER:-1}"
+KEEP_BUILD_ARTIFACTS="${KEEP_BUILD_ARTIFACTS:-0}"
 SCOPER_BIN="$PROJECT_ROOT/vendor/bin/php-scoper"
 ROOT_COMPOSER_JSON="$PROJECT_ROOT/composer.json"
 ROOT_COMPOSER_LOCK="$PROJECT_ROOT/composer.lock"
@@ -25,14 +26,18 @@ on_error() {
 }
 
 cleanup() {
-    rm -rf "$PROJECT_ROOT/build"
+    if [[ "$KEEP_BUILD_ARTIFACTS" != "1" ]]; then
+        rm -rf "$PROJECT_ROOT/build"
+    else
+        echo "Keeping build directory for debugging: $PROJECT_ROOT/build"
+    fi
 
     if [[ "$TOOLING_INSTALLED_BY_SCRIPT" == "1" ]]; then
         echo "Cleaning temporary tooling artifacts."
-        if [[ "$ROOT_VENDOR_WAS_PRESENT" == "0" ]]; then
+        if [[ "$KEEP_BUILD_ARTIFACTS" != "1" && "$ROOT_VENDOR_WAS_PRESENT" == "0" ]]; then
             rm -rf "$ROOT_VENDOR_DIR"
         fi
-        if [[ "$ROOT_LOCK_WAS_PRESENT" == "0" ]]; then
+        if [[ "$KEEP_BUILD_ARTIFACTS" != "1" && "$ROOT_LOCK_WAS_PRESENT" == "0" ]]; then
             rm -f "$ROOT_COMPOSER_LOCK"
         fi
     fi
@@ -165,6 +170,46 @@ scope_vendor_dependencies() {
     run_step "Remove unscoped vendor directory" rm -rf vendor
 }
 
+validate_scoped_autoload_maps() {
+    local autoload_psr4="vendor-prefixed/composer/autoload_psr4.php"
+    local autoload_static="vendor-prefixed/composer/autoload_static.php"
+    local required_prefixed_prefix_keys=(
+        "'TransbankVendor\\Psr\\Log\\\\' =>"
+        "'TransbankVendor\\Psr\\Http\\Message\\\\' =>"
+        "'TransbankVendor\\Psr\\Http\\Client\\\\' =>"
+        "'TransbankVendor\\GuzzleHttp\\Psr7\\\\' =>"
+        "'TransbankVendor\\GuzzleHttp\\Promise\\\\' =>"
+    )
+    local forbidden_unprefixed_keys=(
+        "'Psr\\\\Log\\\\' =>"
+        "'Psr\\\\Http\\\\Message\\\\' =>"
+        "'Psr\\\\Http\\\\Client\\\\' =>"
+        "'GuzzleHttp\\\\Psr7\\\\' =>"
+        "'GuzzleHttp\\\\Promise\\\\' =>"
+    )
+
+    for file in "$autoload_psr4" "$autoload_static"; do
+        if [[ ! -f "$file" ]]; then
+            echo "ERROR: missing scoped autoload map: $file" 1>&2
+            exit 1
+        fi
+
+        for prefix_key in "${required_prefixed_prefix_keys[@]}"; do
+            if ! grep -Fq "$prefix_key" "$file"; then
+                echo "ERROR: missing required prefixed namespace key $prefix_key in $file" 1>&2
+                exit 1
+            fi
+        done
+
+        for prefix_key in "${forbidden_unprefixed_keys[@]}"; do
+            if grep -Fq "$prefix_key" "$file"; then
+                echo "ERROR: found unprefixed scoped namespace key $prefix_key in $file" 1>&2
+                exit 1
+            fi
+        done
+    done
+}
+
 validate_packaging_layout() {
     local unexpected_prefix_pattern="TransbankVendor\\\\Transbank\\\\WooCommerce\\\\WebpayRest\\\\\|TransbankVendor\\\\Transbank\\\\Plugin\\\\"
 
@@ -181,6 +226,8 @@ validate_packaging_layout() {
         echo "ERROR: vendor directory must not exist when php-scoper is enabled" 1>&2
         exit 1
     fi
+
+    validate_scoped_autoload_maps
 
     if find src shared views -type f -name '*.php' -print0 2>/dev/null | xargs -0 grep -q "$unexpected_prefix_pattern"; then
         echo "ERROR: plugin namespaces were prefixed unexpectedly" 1>&2
@@ -229,13 +276,17 @@ package_plugin() {
 
     cd "$PROJECT_ROOT"
 
-    echo "\nPlugin created, the detail is:"
+    echo
+    echo "Plugin created, the detail is:"
     if [[ -n "${TAG:-}" ]]; then
         echo "- Version: $TAG"
     else
         echo "- Version: unchanged (non-release build)"
     fi
     echo "- File name: $PLUGIN_FILE"
+    if [[ "$KEEP_BUILD_ARTIFACTS" == "1" ]]; then
+        echo "- Build dir kept for debugging: $PROJECT_ROOT/build/package-plugin"
+    fi
 }
 
 trap 'on_error $LINENO' ERR

--- a/plugin/load-autoloader.php
+++ b/plugin/load-autoloader.php
@@ -10,48 +10,10 @@ function tbkLoadPluginAutoloader(string $pluginRoot): void
         return;
     }
 
-    $runtimePrefixes = tbkLoadScopedRuntimePrefixes($pluginRoot);
-    if ($runtimePrefixes !== []) {
-        tbkRegisterScopedAutoloader($pluginRoot . 'vendor-prefixed/', $runtimePrefixes);
-    }
-
     $scoperAutoload = $pluginRoot . 'vendor-prefixed/scoper-autoload.php';
     if (file_exists($scoperAutoload)) {
         require_once $scoperAutoload;
     }
 
     require_once $prefixedAutoload;
-}
-
-function tbkLoadScopedRuntimePrefixes(string $pluginRoot): array
-{
-    $scopeConfigPath = $pluginRoot . 'scoper-namespaces.php';
-    if (!file_exists($scopeConfigPath)) {
-        return [];
-    }
-
-    $scopeConfig = require_once $scopeConfigPath;
-    $runtimePrefixes = $scopeConfig['runtime_psr4'] ?? [];
-
-    return is_array($runtimePrefixes) ? $runtimePrefixes : [];
-}
-
-function tbkRegisterScopedAutoloader(string $prefixedRoot, array $runtimePrefixes): void
-{
-    spl_autoload_register(static function ($class) use ($prefixedRoot, $runtimePrefixes) {
-        foreach ($runtimePrefixes as $prefix => $relativeBaseDir) {
-            if (strncmp($class, $prefix, strlen($prefix)) !== 0) {
-                continue;
-            }
-
-            $relativeClass = substr($class, strlen($prefix));
-            $file = $prefixedRoot . $relativeBaseDir . str_replace('\\', '/', $relativeClass) . '.php';
-
-            if (file_exists($file)) {
-                require_once $file;
-            }
-
-            return;
-        }
-    }, true, true);
 }

--- a/scripts/fix_scoper_autoload.sh
+++ b/scripts/fix_scoper_autoload.sh
@@ -29,9 +29,45 @@ $scopeConfigPath = $pluginRoot . '/scoper-namespaces.php';
 $scopeConfig = require_once $scopeConfigPath;
 $replacements = $scopeConfig['autoload_replacements'] ?? [];
 
-if (!is_array($replacements) || $replacements === []) {
+$sourcePrefixReplacements = [
+    "'Psr\\Log\\\\' =>" => "'TransbankVendor\\Psr\\Log\\\\' =>",
+    "'Psr\\Http\\Message\\\\' =>" => "'TransbankVendor\\Psr\\Http\\Message\\\\' =>",
+    "'Psr\\Http\\Client\\\\' =>" => "'TransbankVendor\\Psr\\Http\\Client\\\\' =>",
+    "'GuzzleHttp\\Psr7\\\\' =>" => "'TransbankVendor\\GuzzleHttp\\Psr7\\\\' =>",
+    "'GuzzleHttp\\Promise\\\\' =>" => "'TransbankVendor\\GuzzleHttp\\Promise\\\\' =>",
+];
+
+if (!is_array($replacements)) {
     exit(1);
 }
+
+function writeError(string $message): void
+{
+    $stderr = fopen('php://stderr', 'wb');
+    if ($stderr !== false) {
+        fwrite($stderr, $message);
+        fclose($stderr);
+        return;
+    }
+
+    error_log(rtrim($message));
+}
+
+$requiredPrefixedPrefixKeys = [
+    "'TransbankVendor\\Psr\\Log\\\\' =>",
+    "'TransbankVendor\\Psr\\Http\\Message\\\\' =>",
+    "'TransbankVendor\\Psr\\Http\\Client\\\\' =>",
+    "'TransbankVendor\\GuzzleHttp\\Psr7\\\\' =>",
+    "'TransbankVendor\\GuzzleHttp\\Promise\\\\' =>",
+];
+
+$forbiddenUnprefixedPrefixKeys = [
+    "'Psr\\\\Log\\\\' =>",
+    "'Psr\\\\Http\\\\Message\\\\' =>",
+    "'Psr\\\\Http\\\\Client\\\\' =>",
+    "'GuzzleHttp\\\\Psr7\\\\' =>",
+    "'GuzzleHttp\\\\Promise\\\\' =>",
+];
 
 $targets = [
     $pluginRoot . '/vendor-prefixed/composer/autoload_psr4.php',
@@ -48,10 +84,28 @@ foreach ($targets as $file) {
         exit(1);
     }
 
-    $updated = str_replace(array_keys($replacements), array_values($replacements), $content);
+    $updated = str_replace(
+        array_merge(array_keys($replacements), array_keys($sourcePrefixReplacements)),
+        array_merge(array_values($replacements), array_values($sourcePrefixReplacements)),
+        $content
+    );
 
     if ($updated !== $content && file_put_contents($file, $updated) === false) {
         exit(1);
+    }
+
+    foreach ($requiredPrefixedPrefixKeys as $prefixKey) {
+        if (strpos($updated, $prefixKey) === false) {
+            writeError("Missing required prefixed namespace key in autoload map: {$prefixKey} ({$file})\n");
+            exit(1);
+        }
+    }
+
+    foreach ($forbiddenUnprefixedPrefixKeys as $prefixKey) {
+        if (strpos($updated, $prefixKey) !== false) {
+            writeError("Found forbidden unprefixed namespace key in autoload map: {$prefixKey} ({$file})\n");
+            exit(1);
+        }
     }
 }
 PHP


### PR DESCRIPTION
This PR refines the plugin’s scoped autoload flow to make the packaged runtime more robust when running alongside other WordPress plugins.

  - Removes the extra custom runtime scoped PSR-4 autoloader from load-autoloader.php, leaving Composer’s prefixed autoloader as the single source of vendor class loading.
  - Refines the scoped packaging step so generated Composer autoload maps correctly use prefixed namespaces for PSR and Guzzle-related dependencies.
  - Adds packaging validation to fail the build if scoped autoload maps still contain unexpected unprefixed namespace keys.
  - Adds an optional debug mode in package.sh to keep generated build artifacts for inspection during packaging verification.
  - Cleans up packaging output messaging for easier inspection while validating release artifacts.


### Reference
https://github.com/TransbankDevelopers/transbank-plugin-woocommerce-webpay-rest/issues/363

### Zip
[transbank-webpay-plus-rest.zip](https://github.com/user-attachments/files/26834833/transbank-webpay-plus-rest.zip)

## Test
<img width="1920" height="1775" alt="image" src="https://github.com/user-attachments/assets/744479db-56b8-4300-a360-516916650a9b" />
<img width="1920" height="2164" alt="image" src="https://github.com/user-attachments/assets/a3d8e506-9465-4c24-8412-e1e8a32bfebb" />

