### PR TITLE
TBK-276 feat: scope checkout block styles to checkout blocks

### DIFF
--- a/plugin/src/Blocks/WCGatewayTransbankBlocks.php
+++ b/plugin/src/Blocks/WCGatewayTransbankBlocks.php
@@ -39,7 +39,7 @@ trait WCGatewayTransbankBlocks
             true
         );
 
-        if ($this->frontStyleHandle !== null) {
+        if ($this->frontStyleHandle !== null && $this->shouldEnqueueFrontStyle()) {
             wp_enqueue_style($this->frontStyleHandle);
         }
 
@@ -125,6 +125,20 @@ trait WCGatewayTransbankBlocks
     protected function getProcessErrorHookAcceptedArgs(): int
     {
         return 2;
+    }
+
+    protected function shouldEnqueueFrontStyle(): bool
+    {
+        if (!function_exists('has_block') || !function_exists('get_queried_object_id')) {
+            return false;
+        }
+
+        $postId = get_queried_object_id();
+        if (!$postId) {
+            return false;
+        }
+
+        return has_block('woocommerce/checkout', $postId);
     }
 
     public function processErrorPayment(PaymentContext $context, PaymentResult &$result)

--- a/plugin/src/Blocks/WCGatewayTransbankBlocks.php
+++ b/plugin/src/Blocks/WCGatewayTransbankBlocks.php
@@ -13,6 +13,7 @@ trait WCGatewayTransbankBlocks
 
     private $scriptInfo;
     private $frontStyleHandle;
+    private ?bool $shouldEnqueueFrontStyle = null;
 
     public function initialize()
     {
@@ -129,16 +130,26 @@ trait WCGatewayTransbankBlocks
 
     protected function shouldEnqueueFrontStyle(): bool
     {
-        if (!function_exists('has_block') || !function_exists('get_queried_object_id')) {
-            return false;
+        if ($this->shouldEnqueueFrontStyle !== null) {
+            return $this->shouldEnqueueFrontStyle;
         }
 
-        $postId = get_queried_object_id();
-        if (!$postId) {
-            return false;
+        $shouldEnqueue = false;
+
+        if (function_exists('is_checkout') && is_checkout()) {
+            $shouldEnqueue = true;
+
+            if (function_exists('get_queried_object_id') && function_exists('has_block')) {
+                $postId = get_queried_object_id();
+                if ($postId > 0) {
+                    $shouldEnqueue = has_block('woocommerce/checkout', $postId);
+                }
+            }
         }
 
-        return has_block('woocommerce/checkout', $postId);
+        $this->shouldEnqueueFrontStyle = $shouldEnqueue;
+
+        return $this->shouldEnqueueFrontStyle;
     }
 
     public function processErrorPayment(PaymentContext $context, PaymentResult &$result)


### PR DESCRIPTION
This PR scopes Transbank checkout block CSS so it only loads on pages that actually contain the WooCommerce checkout block, preventing payment styles from leaking into the homepage and other non-checkout views.

## Test
### Home
<img width="1348" height="720" alt="image" src="https://github.com/user-attachments/assets/483dc2c7-37d5-46cf-be8d-17010e5c54b9" />

### Cart
<img width="2704" height="1356" alt="image" src="https://github.com/user-attachments/assets/ab1a45d8-0ff7-4b62-a1c4-4f3bb1e4e7fc" />

### Checkout
<img width="1346" height="875" alt="image" src="https://github.com/user-attachments/assets/cffbbcce-b43c-4c6b-a93c-8606af42562f" />

## Plugin Zip
[transbank-webpay-plus-rest.zip](https://github.com/user-attachments/files/28315043/transbank-webpay-plus-rest.zip)
