### PR TITLE
TBK-310 refine (one-click): add inscription status validation before saving payment method

### DIFF
--- a/plugin/src/Controllers/FinishOneclickController.php
+++ b/plugin/src/Controllers/FinishOneclickController.php
@@ -161,11 +161,13 @@ class FinishOneclickController
                 'from' => $from
             ]);
 
+            $userInfo = wp_get_current_user();
+
+            if (!$userInfo) {
+                throw new EcommerceException('No se encontró el usuario asociado a la inscripción');
+            }
+
             if ($resp->isApproved()) {
-                $userInfo = wp_get_current_user();
-                if (!$userInfo) {
-                    throw new EcommerceException('No se encontró el usuario asociado a la inscripción');
-                }
                 $message = 'Tarjeta inscrita satisfactoriamente. Aún no se realiza ningún cobro. Ahora puedes realizar el pago.';
                 BlocksHelper::addLegacyNotices(__($message, 'transbank_wc_plugin'), 'success');
                 $token = $this->savePaymentToken($ins, $resp);

--- a/plugin/src/Controllers/FinishOneclickController.php
+++ b/plugin/src/Controllers/FinishOneclickController.php
@@ -161,29 +161,41 @@ class FinishOneclickController
                 'from' => $from
             ]);
 
-            $userInfo = wp_get_current_user();
-            if (!$userInfo) {
-                throw new EcommerceException('No se encontró el usuario asociado a la inscripción');
-            }
-            $message = 'Tarjeta inscrita satisfactoriamente. Aún no se realiza ningún cobro. Ahora puedes realizar el pago.';
-            BlocksHelper::addLegacyNotices(__($message, 'transbank_wc_plugin'), 'success');
-            $token = $this->savePaymentToken($ins, $resp);
-            if ($order) {
-                $order->add_order_note('Tarjeta inscrita satisfactoriamente');
-            }
-            $this->inscriptionService->update($ins->id, [
-                'token_id' => $token->get_id(),
-            ]);
+            if ($resp->isApproved()) {
+                $userInfo = wp_get_current_user();
+                if (!$userInfo) {
+                    throw new EcommerceException('No se encontró el usuario asociado a la inscripción');
+                }
+                $message = 'Tarjeta inscrita satisfactoriamente. Aún no se realiza ningún cobro. Ahora puedes realizar el pago.';
+                BlocksHelper::addLegacyNotices(__($message, 'transbank_wc_plugin'), 'success');
+                $token = $this->savePaymentToken($ins, $resp);
+                if ($order) {
+                    $order->add_order_note('Tarjeta inscrita satisfactoriamente');
+                }
+                $this->inscriptionService->update($ins->id, [
+                    'token_id' => $token->get_id(),
+                ]);
 
-            WC_Payment_Tokens::set_users_default(get_current_user_id(), $token->get_id());
+                WC_Payment_Tokens::set_users_default(get_current_user_id(), $token->get_id());
 
-            do_action('wc_transbank_oneclick_inscription_approved', [
-                'transbankInscriptionResponse' => $resp,
-                'transbankToken' => $token,
-                'from' => $from
-            ]);
-            $this->log->logInfo('Inscripción finalizada correctamente', ['user' => $ins->user_id]);
-            $this->redirectUser($from, BlocksHelper::ONECLICK_SUCCESSFULL_INSCRIPTION);
+                do_action('wc_transbank_oneclick_inscription_approved', [
+                    'transbankInscriptionResponse' => $resp,
+                    'transbankToken' => $token,
+                    'from' => $from
+                ]);
+                $this->log->logInfo('Inscripción finalizada correctamente', ['user' => $ins->user_id]);
+                $this->redirectUser($from, BlocksHelper::ONECLICK_SUCCESSFULL_INSCRIPTION);
+            } else {
+                $this->log->logInfo('Inscripción rechazada', [
+                    'responseCode' => $resp->getResponseCode(),
+                    'user'         => $ins->user_id,
+                ]);
+                BlocksHelper::addLegacyNotices(
+                    __('La inscripción fue rechazada. Por favor, intenta nuevamente con otra tarjeta.', 'transbank_wc_plugin'),
+                    'error'
+                );
+                $this->redirectUser($from, BlocksHelper::ONECLICK_REJECTED_INSCRIPTION);
+            }
         } catch (Exception $e) {
             $errorContext = [
                 'token' => $token,

--- a/plugin/src/Controllers/FinishOneclickController.php
+++ b/plugin/src/Controllers/FinishOneclickController.php
@@ -190,6 +190,7 @@ class FinishOneclickController
                     'responseCode' => $resp->getResponseCode(),
                     'user'         => $ins->user_id,
                 ]);
+                $order->add_order_note('Inscripción de tarjeta rechazada por Transbank. Código de respuesta: ' . $resp->getResponseCode());
                 BlocksHelper::addLegacyNotices(
                     __('La inscripción fue rechazada. Por favor, intenta nuevamente con otra tarjeta.', 'transbank_wc_plugin'),
                     'error'

--- a/plugin/src/Controllers/FinishOneclickController.php
+++ b/plugin/src/Controllers/FinishOneclickController.php
@@ -192,7 +192,11 @@ class FinishOneclickController
                     'responseCode' => $resp->getResponseCode(),
                     'user'         => $ins->user_id,
                 ]);
-                $order->add_order_note('Inscripción de tarjeta rechazada por Transbank. Código de respuesta: ' . $resp->getResponseCode());
+
+                if ($order) {
+                    $order->add_order_note('Inscripción de tarjeta rechazada por Transbank. Código de respuesta: ' . $resp->getResponseCode());
+                }
+
                 BlocksHelper::addLegacyNotices(
                     __('La inscripción fue rechazada. Por favor, intenta nuevamente con otra tarjeta.', 'transbank_wc_plugin'),
                     'error'


### PR DESCRIPTION
## Description

On PHP version upgrade, substr() became fatal when receiving null. The root cause was that a rejected One Click inscription returns a payload with null data, and the flow had no status validation — null values reached savePaymentMethod() unconditionally.

## Changes

- Add a status check to separate the handling of approved and rejected inscriptions into distinct flows (`FinishOneclickController.php` - line 164)

## Test

- My account:
  - Abort
    <img width="1172" height="986" alt="My account - Abort" src="https://github.com/user-attachments/assets/93dc983f-5729-41fb-abee-584e7834956c" />
  - Reject
    <img width="1172" height="986" alt="My account - Reject" src="https://github.com/user-attachments/assets/75c484cf-7c58-4b50-9e2e-c7f1e59b2c6c" />
  - Success
    <img width="1172" height="986" alt="My account - Success" src="https://github.com/user-attachments/assets/85bde6c1-16e6-4fb3-8b35-ee3ec5d9126f" />
  - Delete
    <img width="1172" height="986" alt="My account - Delete" src="https://github.com/user-attachments/assets/4323e2fc-89c4-469f-b4bb-7250e9d9afd0" />
- Checkout:
  - Abort
    <img width="1172" height="986" alt="Checkout - Abort" src="https://github.com/user-attachments/assets/b523fa5e-fb83-4504-84ce-be15730645a6" />
  - Reject
    <img width="1172" height="986" alt="Checkout - Reject" src="https://github.com/user-attachments/assets/d1e754a6-32e3-4f04-8b55-fb98d1a04962" />
  - Success
    <img width="1172" height="986" alt="Checkout - Success" src="https://github.com/user-attachments/assets/1bd723be-d1f5-451e-a7a7-2fcca8ae0a68" />
- Log Plugin WordPress
  <img width="1757" height="364" alt="Log debug WordPress" src="https://github.com/user-attachments/assets/2e5dc0c0-7a08-4c2a-a8c1-791e27552d2d" />

## Plugin ZIP
[transbank-webpay-plus-rest.zip](https://github.com/user-attachments/files/28726258/transbank-webpay-plus-rest.zip)