### PR TITLE
feat: refine webpay return

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -59,7 +59,7 @@ RUN mkdir -p /etc/apt/keyrings \
  && apt-get update \
  && apt-get install -y --no-install-recommends nodejs \
  && corepack enable \
- && corepack prepare pnpm@11.5.1 --activate \
+ && corepack prepare pnpm@11.5.2 --activate \
  && npm install --ignore-scripts -g npm@latest \
  && rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/build-and-scan.yml
+++ b/.github/workflows/build-and-scan.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: "22"
       - name: Prepare pnpm
-        run: corepack prepare pnpm@11.5.1 --activate
+        run: corepack prepare pnpm@11.5.2 --activate
       - name: Package Plugin
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: "22"
       - name: Prepare pnpm
-        run: corepack prepare pnpm@11.5.1 --activate
+        run: corepack prepare pnpm@11.5.2 --activate
       - name: Install SVN
         run: |
           sudo apt-get update

--- a/plugin/composer.json
+++ b/plugin/composer.json
@@ -2,10 +2,10 @@
     "description": "Transbank WooCommerce Plugin",
     "name": "transbank/woocommerce-plugin",
     "require": {
-        "transbank/transbank-sdk": "^5.0",
+        "transbank/transbank-sdk": "5.1.0",
         "ext-json": "*",
         "php": ">=8.2",
-        "monolog/monolog": "3.10"
+        "monolog/monolog": "3.10.0"
     },
     "config": {
         "platform": {
@@ -19,7 +19,7 @@
         }
     },
     "require-dev": {
-        "php-stubs/wordpress-stubs": "^6.9",
-        "php-stubs/woocommerce-stubs": "^10.4"
+        "php-stubs/wordpress-stubs": "6.9.4",
+        "php-stubs/woocommerce-stubs": "10.8.0"
     }
 }

--- a/plugin/composer.lock
+++ b/plugin/composer.lock
@@ -4,29 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f6e1557513b25646ab1b95c528dcf2b9",
+    "content-hash": "45dda5e9f50a385c2cffdee44f50c2f8",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
+                "reference": "5af96f374e0ab4ebd747b8310888c99d3adb0a8c",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.11",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -35,8 +36,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.5",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -114,7 +116,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.11.1"
             },
             "funding": [
                 {
@@ -130,28 +132,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-07T22:54:06+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -197,7 +200,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -213,27 +216,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/bbb5e61349fa5cb822b3e87842b951088b76b81f",
+                "reference": "bbb5e61349fa5cb822b3e87842b951088b76b81f",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.24"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -241,9 +246,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -314,7 +319,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.11.0"
             },
             "funding": [
                 {
@@ -330,7 +335,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-02T12:30:48+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -691,16 +696,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -713,7 +718,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -738,7 +743,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -750,11 +755,99 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "transbank/transbank-sdk",
@@ -810,16 +903,16 @@
     "packages-dev": [
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v10.6.0",
+            "version": "v10.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "613d2b5107900c3ff33ce7827f55e2af0b2e28d8"
+                "reference": "9d59e65dcabc18153c243cb9acd85fc88ef40589"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/613d2b5107900c3ff33ce7827f55e2af0b2e28d8",
-                "reference": "613d2b5107900c3ff33ce7827f55e2af0b2e28d8",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/9d59e65dcabc18153c243cb9acd85fc88ef40589",
+                "reference": "9d59e65dcabc18153c243cb9acd85fc88ef40589",
                 "shasum": ""
             },
             "require": {
@@ -848,22 +941,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.6.0"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.8.0"
             },
-            "time": "2026-03-11T04:30:36+00:00"
+            "time": "2026-05-27T11:46:50+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.9.1",
+            "version": "v6.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7"
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
-                "reference": "f12220f303e0d7c0844c0e5e957b0c3cee48d2f7",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
                 "shasum": ""
             },
             "conflict": {
@@ -873,7 +966,7 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.3",
+                "php-stubs/generator": "^0.8.6",
                 "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
@@ -900,9 +993,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
             },
-            "time": "2026-02-03T19:29:21+00:00"
+            "time": "2026-05-01T20:36:01+00:00"
         }
     ],
     "aliases": [],

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -5,10 +5,9 @@
     "author": "Transbank Developers",
     "license": "BSD-3-Clause",
     "keywords": [],
-    "packageManager": "pnpm@11.5.1",
     "engines": {
         "node": "^22.13.0",
-        "pnpm": ">=11.5.1"
+        "pnpm": ">=11.5.2"
     },
     "devDependencies": {
         "@woocommerce/dependency-extraction-webpack-plugin": "4.0.0",

--- a/plugin/shared/Helpers/PluginLogger.php
+++ b/plugin/shared/Helpers/PluginLogger.php
@@ -92,6 +92,11 @@ final class PluginLogger
         $this->logger->error($msg, $context);
     }
 
+    public function logWarning(string $msg, array $context = [])
+    {
+        $this->logger->warning($msg, $context);
+    }
+
     public static function sanitizeContextForLogs(array $context): array
     {
         $sanitizedContext = [];

--- a/plugin/src/Controllers/CommitWebpayController.php
+++ b/plugin/src/Controllers/CommitWebpayController.php
@@ -9,6 +9,7 @@ use Transbank\Plugin\Helpers\TbkConstants;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 use Transbank\WooCommerce\WebpayRest\Infrastructure\Lock\MySqlNamedLock;
+use Transbank\WooCommerce\WebpayRest\Exceptions\MySqlNamedLockException;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkFactory;
 use Transbank\WooCommerce\WebpayRest\Services\EcommerceService;
 use Transbank\WooCommerce\WebpayRest\Services\TransactionService;
@@ -174,20 +175,19 @@ class CommitWebpayController
      */
     protected function handleNormalFlow(string $token): void
     {
+        $lockAcquired = false;
         $this->log->logInfo(
             "Procesando transacción por flujo Normal",
             PluginLogger::sanitizeContextForLogs(['token' => $token])
         );
 
-        if (!$this->webpayReturnLock->acquire($token)) {
-            $this->log->logInfo(
-                'Retorno de Webpay ya se encuentra en procesamiento',
-                PluginLogger::sanitizeContextForLogs(['token' => $token])
-            );
-            return;
-        }
-
         try {
+            $lockAcquired = $this->acquireWebpayReturnLock($token);
+
+            if (!$lockAcquired) {
+                return;
+            }
+
             if ($this->transactionService->checkIsAlreadyProcessed($token)) {
                 $this->handleTransactionAlreadyProcessed($token);
                 return;
@@ -223,7 +223,59 @@ class CommitWebpayController
                 $this->handleUnauthorizedTransaction($webpayTransaction, $commitResponse);
             }
         } finally {
-            $this->webpayReturnLock->release($token);
+            $this->releaseWebpayReturnLock($token, $lockAcquired);
+        }
+    }
+
+    /**
+     * Tries to acquire the return lock for a token.
+     *
+     * @param string $token
+     * @return bool True when the lock is acquired, false when another request is already processing.
+     */
+    private function acquireWebpayReturnLock(string $token): bool
+    {
+        $lockAcquired = $this->webpayReturnLock->acquire($token);
+
+        if (!$lockAcquired) {
+            $this->log->logInfo(
+                'Retorno de Webpay ya se encuentra en procesamiento',
+                PluginLogger::sanitizeContextForLogs(['token' => $token])
+            );
+        }
+
+        return $lockAcquired;
+    }
+
+    /**
+     * Releases the return lock only when it was actually acquired.
+     *
+     * @param string $token
+     * @param bool $lockAcquired
+     * @return void
+     */
+    private function releaseWebpayReturnLock(string $token, bool $lockAcquired): void
+    {
+        if (!$lockAcquired) {
+            return;
+        }
+
+        try {
+            $released = $this->webpayReturnLock->release($token);
+            if (!$released) {
+                $this->log->logWarning(
+                    'No se pudo liberar el lock de retorno de Webpay',
+                    PluginLogger::sanitizeContextForLogs(['token' => $token])
+                );
+            }
+        } catch (MySqlNamedLockException $e) {
+            $this->log->logWarning(
+                'Error al liberar el lock de retorno de Webpay',
+                PluginLogger::sanitizeContextForLogs([
+                    'token' => $token,
+                    'error' => $e->getMessage(),
+                ])
+            );
         }
     }
 

--- a/plugin/src/Controllers/CommitWebpayController.php
+++ b/plugin/src/Controllers/CommitWebpayController.php
@@ -8,6 +8,7 @@ use Transbank\WooCommerce\WebpayRest\Helpers\RequestInputHelper;
 use Transbank\Plugin\Helpers\TbkConstants;
 use Transbank\Plugin\Exceptions\EcommerceException;
 use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
+use Transbank\WooCommerce\WebpayRest\Infrastructure\Lock\MySqlNamedLock;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkFactory;
 use Transbank\WooCommerce\WebpayRest\Services\EcommerceService;
 use Transbank\WooCommerce\WebpayRest\Services\TransactionService;
@@ -41,15 +42,18 @@ class CommitWebpayController
     protected TransactionService $transactionService;
     protected WebpayService $webpayService;
     protected EcommerceService $ecommerceService;
+    protected MySqlNamedLock $webpayReturnLock;
 
     /**
      * Constructor initializes the logger.
      */
     public function __construct()
     {
+        global $wpdb;
         $this->transactionService = TbkFactory::createTransactionService();
         $this->webpayService = TbkFactory::createWebpayService();
         $this->ecommerceService = TbkFactory::createEcommerceService();
+        $this->webpayReturnLock = new MySqlNamedLock($wpdb);
         $this->log = TbkFactory::createWebpayPlusLogger();
     }
 
@@ -175,39 +179,51 @@ class CommitWebpayController
             PluginLogger::sanitizeContextForLogs(['token' => $token])
         );
 
-        if ($this->transactionService->checkIsAlreadyProcessed($token)) {
-            $this->handleTransactionAlreadyProcessed($token);
+        if (!$this->webpayReturnLock->acquire($token)) {
+            $this->log->logInfo(
+                'Retorno de Webpay ya se encuentra en procesamiento',
+                PluginLogger::sanitizeContextForLogs(['token' => $token])
+            );
             return;
         }
 
-        $webpayTransaction = $this->transactionService->findFirstByToken($token);
+        try {
+            if ($this->transactionService->checkIsAlreadyProcessed($token)) {
+                $this->handleTransactionAlreadyProcessed($token);
+                return;
+            }
 
-        if (!$webpayTransaction) {
-            $message = "No se encontró la transacción para el token proporcionado.";
-            $this->log->logError(
-                $message,
-                PluginLogger::sanitizeContextForLogs(['token' => $token])
-            );
-            throw new EcommerceException($message);
-        }
+            $webpayTransaction = $this->transactionService->findFirstByToken($token);
 
-        $wooCommerceOrder = $this->ecommerceService->getOrderById($webpayTransaction->order_id);
-        $commitResponse = $this->webpayService->commitTransaction($token);
+            if (!$webpayTransaction) {
+                $message = "No se encontró la transacción para el token proporcionado.";
+                $this->log->logError(
+                    $message,
+                    PluginLogger::sanitizeContextForLogs(['token' => $token])
+                );
+                throw new EcommerceException($message);
+            }
 
-        if ($commitResponse->getStatus() === null || $commitResponse->getResponseCode() === null) {
-            $message = "La respuesta de confirmación de Transbank es inválida.";
-            $this->log->logError($message, PluginLogger::sanitizeContextForLogs(['token' => $token]));
-            throw new EcommerceException($message);
-        }
+            $wooCommerceOrder = $this->ecommerceService->getOrderById($webpayTransaction->order_id);
+            $commitResponse = $this->webpayService->commitTransaction($token);
 
-        if ($commitResponse->isApproved()) {
-            $this->handleAuthorizedTransaction(
-                $wooCommerceOrder,
-                $webpayTransaction,
-                $commitResponse
-            );
-        } else {
-            $this->handleUnauthorizedTransaction($webpayTransaction, $commitResponse);
+            if ($commitResponse->getStatus() === null || $commitResponse->getResponseCode() === null) {
+                $message = "La respuesta de confirmación de Transbank es inválida.";
+                $this->log->logError($message, PluginLogger::sanitizeContextForLogs(['token' => $token]));
+                throw new EcommerceException($message);
+            }
+
+            if ($commitResponse->isApproved()) {
+                $this->handleAuthorizedTransaction(
+                    $wooCommerceOrder,
+                    $webpayTransaction,
+                    $commitResponse
+                );
+            } else {
+                $this->handleUnauthorizedTransaction($webpayTransaction, $commitResponse);
+            }
+        } finally {
+            $this->webpayReturnLock->release($token);
         }
     }
 

--- a/plugin/src/Exceptions/MySqlNamedLockException.php
+++ b/plugin/src/Exceptions/MySqlNamedLockException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Transbank\WooCommerce\WebpayRest\Exceptions;
+
+use RuntimeException;
+
+class MySqlNamedLockException extends RuntimeException
+{
+}

--- a/plugin/src/Infrastructure/Lock/MySQLNamedLock.php
+++ b/plugin/src/Infrastructure/Lock/MySQLNamedLock.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Transbank\WooCommerce\WebpayRest\Infrastructure\Lock;
+
+use wpdb;
+
+/**
+ * Thin MySQL named lock adapter.
+ *
+ * It provides a reusable acquire/release primitive for flows that need to serialize work by key.
+ */
+class MySqlNamedLock
+{
+    private const LOCK_PREFIX = 'transbank_webpay_lock_';
+
+    private wpdb $db;
+
+    public function __construct(wpdb $wpdb)
+    {
+        $this->db = $wpdb;
+    }
+
+    public function acquire(string $key): bool
+    {
+        $lockName = $this->buildLockName($key);
+        $query = $this->db->prepare('SELECT GET_LOCK(%s, 0)', $lockName);
+
+        return (string) $this->db->get_var($query) === '1';
+    }
+
+    public function release(string $key): void
+    {
+        $lockName = $this->buildLockName($key);
+        $query = $this->db->prepare('SELECT RELEASE_LOCK(%s)', $lockName);
+        $this->db->get_var($query);
+    }
+
+    private function buildLockName(string $key): string
+    {
+        return self::LOCK_PREFIX . sha1($key);
+    }
+}

--- a/plugin/src/Infrastructure/Lock/MySQLNamedLock.php
+++ b/plugin/src/Infrastructure/Lock/MySQLNamedLock.php
@@ -37,6 +37,6 @@ class MySqlNamedLock
 
     private function buildLockName(string $key): string
     {
-        return self::LOCK_PREFIX . sha1($key);
+        return self::LOCK_PREFIX . substr(hash('sha256', $key), 0, 40);
     }
 }

--- a/plugin/src/Infrastructure/Lock/MySQLNamedLock.php
+++ b/plugin/src/Infrastructure/Lock/MySQLNamedLock.php
@@ -3,6 +3,7 @@
 namespace Transbank\WooCommerce\WebpayRest\Infrastructure\Lock;
 
 use wpdb;
+use Transbank\WooCommerce\WebpayRest\Exceptions\MySqlNamedLockException;
 
 /**
  * Thin MySQL named lock adapter.
@@ -24,15 +25,30 @@ class MySqlNamedLock
     {
         $lockName = $this->buildLockName($key);
         $query = $this->db->prepare('SELECT GET_LOCK(%s, 0)', $lockName);
+        $result = $this->db->get_var($query);
 
-        return (string) $this->db->get_var($query) === '1';
+        if ($result === null) {
+            throw new MySqlNamedLockException(
+                'No se pudo adquirir el lock de retorno de Webpay: error al consultar MySQL.'
+            );
+        }
+
+        return $result === '1';
     }
 
-    public function release(string $key): void
+    public function release(string $key): bool
     {
         $lockName = $this->buildLockName($key);
         $query = $this->db->prepare('SELECT RELEASE_LOCK(%s)', $lockName);
-        $this->db->get_var($query);
+        $result = $this->db->get_var($query);
+
+        if ($result === null) {
+            throw new MySqlNamedLockException(
+                'No se pudo liberar el lock de retorno de Webpay: error al consultar MySQL.'
+            );
+        }
+
+        return $result === '1';
     }
 
     private function buildLockName(string $key): string


### PR DESCRIPTION
This PR refines the Webpay commit workflow to safely handle concurrent return requests.

When Webpay sends multiple return calls for the same transaction, only the first request is allowed to continue through the normal commit flow. Any concurrent duplicate requests are intentionally aborted early by a lock to prevent double processing.

This is expected behavior: the user only sees the first return flow, while the other requests occur backend-to-backend and should be ignored once processing is already in progress.

If the first request acquires the lock but later fails, the error is handled through the normal error flow. This keeps the control flow consistent and lets the existing error handling mechanisms decide the final outcome.

The change helps prevent race conditions, duplicate commits, and inconsistent payment states.

## Test
<img width="1641" height="476" alt="image" src="https://github.com/user-attachments/assets/64ab10ae-ee67-4700-b7d2-2761d2a97343" />
<img width="1920" height="2030" alt="image" src="https://github.com/user-attachments/assets/828f176d-b6a8-4ad4-9fd0-355d68c25351" />
