### PR TITLE
TBK-327 feat: refine oneclick aborted flow classification

### DIFF
--- a/plugin/src/Controllers/FinishOneclickController.php
+++ b/plugin/src/Controllers/FinishOneclickController.php
@@ -97,7 +97,7 @@ class FinishOneclickController
         if ($token && !$tbkSessionId && !$tbkOrdenCompra) {
             return self::ONECLICK_NORMAL_FLOW;
         }
-        if ($token && $tbkSessionId && $tbkOrdenCompra) {
+        if ($token && $tbkOrdenCompra) {
             return self::ONECLICK_ABORTED_FLOW;
         }
 


### PR DESCRIPTION
## Description
Aligned aborted inscription classification with current Transbank API behavior. Aborted Oneclick inscriptions return with value only TBK_TOKEN and TBK_ORDEN_COMPRA, making TBK_ID_SESION validation unnecessary.

## Changes
- Removed TBK_ID_SESION verification from FinishOneclickController.php (line 100).

## Test
- My account:
  - Abort
<img width="1188" height="962" alt="My account - Abort" src="https://github.com/user-attachments/assets/5512a35c-a672-4623-856f-e6c2ad3aa21c" />

  - Reject
<img width="1188" height="962" alt="My account - Reject" src="https://github.com/user-attachments/assets/3123bc9f-8d9b-4d8e-8857-cef48b219416" />

  - Success
<img width="1188" height="962" alt="My account - Success" src="https://github.com/user-attachments/assets/102c62c8-7402-43b8-a5c6-6ea2c6a50421" />

  - Delete
<img width="1188" height="962" alt="My account - Delete" src="https://github.com/user-attachments/assets/73458b80-ab6c-4abe-b7d7-a5a2a72dac26" />

- Checkout:
  - Abort
<img width="1188" height="962" alt="Checkout - Abort" src="https://github.com/user-attachments/assets/6a50fec3-2995-454a-9e05-61c93d7307e1" />

  - Reject
<img width="1188" height="962" alt="Checkout - Reject" src="https://github.com/user-attachments/assets/0795e1bf-3a10-4b1f-92ac-72e4d386d5dc" />

  - Success
<img width="1188" height="962" alt="Checkout - Success" src="https://github.com/user-attachments/assets/d0414b51-604d-4546-b3ed-4cc212daadbc" />

- Log Plugin WordPress
[log_transbank_6a2976fcc27a04.77994193-2026-06-10.log](https://github.com/user-attachments/files/28801924/log_transbank_6a2976fcc27a04.77994193-2026-06-10.log)

## ZIP
[transbank-webpay-plus-rest.zip](https://github.com/user-attachments/files/28802131/transbank-webpay-plus-rest.zip)