### PR TITLE
TBK-339 feat: update webpay flow for concurrent requests

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       MYSQL_DATABASE: wordpress
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
+    ports:
+      - "3306:3306"
     volumes:
       - db_data:/var/lib/mysql
 

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ build
 # Devcontainer logs
 .devcontainer/logs
 
+# E2E tests (Playwright)
+tests/e2e/node_modules/
+tests/e2e/test-results/
+tests/e2e/playwright-report/
+tests/e2e/blob-report/
+tests/e2e/.env

--- a/plugin/src/Controllers/CommitWebpayController.php
+++ b/plugin/src/Controllers/CommitWebpayController.php
@@ -182,10 +182,12 @@ class CommitWebpayController
         );
 
         try {
-            $lockAcquired = $this->acquireWebpayReturnLock($token);
+            $lockAcquired = $this->acquireWebpayReturnLockWithRetries($token);
 
             if (!$lockAcquired) {
-                return;
+                throw new EcommerceException(
+                    "No se pudo adquirir el lock de retorno para token: {$token}"
+                );
             }
 
             if ($this->transactionService->checkIsAlreadyProcessed($token)) {
@@ -228,23 +230,37 @@ class CommitWebpayController
     }
 
     /**
-     * Tries to acquire the return lock for a token.
+     * Tries to acquire the return lock with internal retries.
      *
-     * @param string $token
-     * @return bool True when the lock is acquired, false when another request is already processing.
+     * @param string $token The transaction token.
+     * @return bool True when the lock is acquired, false when all retries are exhausted.
      */
-    private function acquireWebpayReturnLock(string $token): bool
+    private function acquireWebpayReturnLockWithRetries(string $token): bool
     {
-        $lockAcquired = $this->webpayReturnLock->acquire($token);
+        $maxAttempts = 4;
 
-        if (!$lockAcquired) {
-            $this->log->logInfo(
-                'Retorno de Webpay ya se encuentra en procesamiento',
-                PluginLogger::sanitizeContextForLogs(['token' => $token])
-            );
+        for ($attempt = 1; $attempt <= $maxAttempts; $attempt++) {
+            try {
+                if ($this->webpayReturnLock->acquire($token)) {
+                    return true;
+                }
+
+                $this->log->logInfo(
+                    "Lock de retorno ocupado, intento {$attempt}/{$maxAttempts}",
+                    PluginLogger::sanitizeContextForLogs(['token' => $token])
+                );
+            } catch (\Throwable $e) {
+                $this->log->logError(
+                    "Error al adquirir lock de retorno, intento {$attempt}/{$maxAttempts}",
+                    PluginLogger::sanitizeContextForLogs([
+                        'token' => $token,
+                        'error' => $e->getMessage(),
+                    ])
+                );
+            }
         }
 
-        return $lockAcquired;
+        return false;
     }
 
     /**

--- a/plugin/src/Controllers/CommitWebpayController.php
+++ b/plugin/src/Controllers/CommitWebpayController.php
@@ -185,9 +185,7 @@ class CommitWebpayController
             $lockAcquired = $this->acquireWebpayReturnLockWithRetries($token);
 
             if (!$lockAcquired) {
-                throw new EcommerceException(
-                    "No se pudo adquirir el lock de retorno para token: {$token}"
-                );
+                throw new EcommerceException('No se pudo adquirir el lock de retorno de Webpay.');
             }
 
             if ($this->transactionService->checkIsAlreadyProcessed($token)) {

--- a/plugin/src/Infrastructure/Lock/MySqlNamedLock.php
+++ b/plugin/src/Infrastructure/Lock/MySqlNamedLock.php
@@ -12,7 +12,7 @@ use Transbank\WooCommerce\WebpayRest\Exceptions\MySqlNamedLockException;
  */
 class MySqlNamedLock
 {
-    private const GET_LOCK_TIMEOUT_SECONDS = 10;
+    private const GET_LOCK_TIMEOUT_SECONDS = 5;
     private const MAX_LOCK_NAME_LENGTH = 64;
 
     private wpdb $db;

--- a/tests/e2e/.env.example
+++ b/tests/e2e/.env.example
@@ -1,0 +1,8 @@
+BASE_URL=http://localhost:8000
+CUSTOMER_EMAIL=admin
+CUSTOMER_PASSWORD=admin
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=wordpress
+DB_PASSWORD=wordpress
+DB_NAME=wordpress

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -1,0 +1,109 @@
+# E2E Tests — Transbank WooCommerce Plugin
+
+Tests end-to-end con Playwright que validan los flujos de pago del plugin Transbank sobre una instancia real de WooCommerce + MySQL corriendo en el devcontainer.
+
+## Qué se valida actualmente
+
+### Webpay Plus
+
+| Test                     | Archivo                                                        | Descripción                                                                                                                                         |
+| ------------------------ | -------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Pago exitoso             | `webpay-plus/payment-validate/successful-payment.spec.js`      | Flujo completo: login → carrito → checkout → pago en Transbank → confirmación de orden                                                              |
+| Lock previene duplicados | `webpay-plus/payment-validate/concurrent-lock-success.spec.js` | Simula dos requests retornando con el mismo token simultáneamente. Verifica que no se creen órdenes duplicadas                                      |
+| Retry con lock ocupado   | `webpay-plus/payment-validate/concurrent-retry-success.spec.js`| Fuerza el timeout de `GET_LOCK` adquiriendo el lock externamente. Verifica que el reintento interno procesa la transacción correctamente             |
+| Reintentos agotados      | `webpay-plus/payment-validate/concurrent-retry-failure.spec.js`| Duplica el request en el retorno. Ambos requests agotan los reintentos internos contra un lock externo. Verifica página de error sin duplicar la orden |
+
+## Prerequisitos
+
+- Devcontainer corriendo (`docker compose up` desde `.devcontainer/`).
+- Plugin Webpay instalado y configurado en modo integración.
+- Usuario de WordPress para iniciar sesión en el checkout. El devcontainer crea por defecto el administrador `admin` / `admin` (ver `.devcontainer/wp-setup.sh`); el login de WooCommerce acepta tanto username como email en el campo `CUSTOMER_EMAIL`.
+- Navegadores de Playwright instalados.
+
+## Setup
+
+```bash
+cd tests/e2e
+pnpm install
+pnpm setup
+```
+
+Copiar `.env.example` a `.env` y ajustar si es necesario:
+
+```bash
+cp .env.example .env
+```
+
+## Variables de entorno
+
+| Variable            | Default                  | Descripción                     |
+| ------------------- | ------------------------ | ------------------------------- |
+| `BASE_URL`          | `http://localhost:8000`  | URL de la instancia WooCommerce |
+| `CUSTOMER_EMAIL`    | `admin`                  | Username o email para login     |
+| `CUSTOMER_PASSWORD` | `admin`                  | Contraseña del usuario anterior |
+| `DB_HOST`           | `localhost`              | Host de MySQL                   |
+| `DB_PORT`           | `3306`                   | Puerto de MySQL                 |
+| `DB_USER`           | `wordpress`              | Usuario de MySQL                |
+| `DB_PASSWORD`       | `wordpress`              | Contraseña de MySQL             |
+| `DB_NAME`           | `wordpress`              | Nombre de la base de datos      |
+
+## Ejecución
+
+```bash
+# Todos los tests
+pnpm test
+
+# Tests de Webpay Plus
+pnpm test:webpay-plus
+
+# Modo debug (Playwright Inspector)
+pnpm test:debug
+```
+
+Todos los comandos corren en modo **headed** (con navegador visible).
+
+## Ver resultados
+
+Playwright genera un reporte HTML después de cada ejecución:
+
+```bash
+pnpm report
+```
+
+Cuando un test falla se guardan automáticamente en `test-results/`:
+
+- **Screenshot** de la página al momento del fallo.
+- **Trace** interactivo (se abre con `pnpm playwright show-trace <archivo.zip>`).
+- **Video** de la ejecución completa del test.
+
+## Estructura
+
+```
+tests/e2e/
+├── specs/                        # Tests agrupados por medio de pago
+│   └── webpay-plus/
+│       └── payment-validate/     # Tests de validación de pago
+├── helpers/                      # Funciones reutilizables
+│   ├── checkout.js               # Login, carrito, checkout WooCommerce
+│   ├── webpay-form.js            # Formulario de tarjeta Transbank
+│   ├── database.js               # Queries a MySQL vía mysql2
+│   ├── concurrent.js             # Helpers de concurrencia (interceptor, holdReturnRequests)
+│   └── assertions.js             # Assertions reutilizables (expectOrderConfirmation, expectPaymentError, etc.)
+├── playwright.config.js
+├── package.json
+├── .env.example
+└── .env                          # (gitignored)
+```
+
+## Agregar nuevos tests
+
+1. Crear una carpeta en `specs/` para el medio de pago (ej. `specs/oneclick/`).
+2. Crear archivos `.spec.js` dentro de esa carpeta.
+3. Reutilizar los helpers existentes o agregar nuevos en `helpers/`.
+4. Agregar un script `test:<medio>` en `package.json` para ejecutar solo esa sección.
+
+## Notas
+
+- Los tests corren con `workers: 1` y `fullyParallel: false` porque comparten estado en la base de datos.
+- El timeout general es de 120 segundos por test, dado que involucran redirecciones externas a Transbank.
+- `database.js` se conecta a MySQL vía `mysql2` con queries parametrizadas. Los valores por defecto de conexión coinciden con los del `docker-compose.yml`.

--- a/tests/e2e/helpers/assertions.js
+++ b/tests/e2e/helpers/assertions.js
@@ -1,0 +1,58 @@
+import { expect } from "@playwright/test";
+
+export function hasFatalError(content) {
+    return (
+        content.includes("Fatal error") ||
+        content.includes("500 Internal Server Error")
+    );
+}
+
+export function isOrderConfirmation(url) {
+    return url.includes("order-received");
+}
+
+export function isPaymentError(url) {
+    return url.includes("transbank_status=");
+}
+
+export async function expectOrderConfirmation(page) {
+    const url = page.url();
+    const content = await page.content();
+
+    expect(hasFatalError(content), `Page has fatal errors — url: ${url}`).toBe(
+        false,
+    );
+    expect(
+        isOrderConfirmation(url),
+        `Expected order-received in URL — got: ${url}`,
+    ).toBe(true);
+}
+
+export async function expectPaymentError(page) {
+    const url = page.url();
+    const content = await page.content();
+
+    expect(hasFatalError(content), `Page has fatal errors — url: ${url}`).toBe(
+        false,
+    );
+    expect(
+        isPaymentError(url),
+        `Expected payment error — url: ${url}`,
+    ).toBe(true);
+}
+
+export async function expectValidResponse(page, label) {
+    const url = page.url();
+    const content = await page.content();
+    const fatal = hasFatalError(content);
+    const confirmation = isOrderConfirmation(url);
+    const paymentErr = isPaymentError(url);
+
+    expect(fatal, `${label} has fatal errors — url: ${url}`).toBe(false);
+    expect(
+        confirmation || paymentErr,
+        `${label} must show confirmation or error — url: ${url}`,
+    ).toBe(true);
+
+    return { confirmation, paymentErr };
+}

--- a/tests/e2e/helpers/checkout.js
+++ b/tests/e2e/helpers/checkout.js
@@ -1,0 +1,29 @@
+const CUSTOMER = {
+    email: process.env.CUSTOMER_EMAIL,
+    password: process.env.CUSTOMER_PASSWORD
+};
+
+export async function login(page) {
+    await page.goto("/?page_id=8");
+    await page.locator("#username").fill(CUSTOMER.email);
+    await page.locator("#password").fill(CUSTOMER.password);
+    await page.locator('button[name="login"]').click();
+    await page.waitForLoadState("domcontentloaded", { timeout: 15_000 });
+}
+
+export async function addProductToCart(page) {
+    await page.goto("/?post_type=product");
+    await page.locator('[data-wp-text="state.addToCartText"]').first().click();
+    await page.waitForTimeout(2_000);
+    await page.goto("/?page_id=6");
+    await page.waitForLoadState("domcontentloaded");
+}
+
+export async function goThroughCheckoutWithWebpay(page) {
+    await page.goto("/?page_id=7");
+    await page.waitForLoadState("domcontentloaded");
+    await page.locator(".wc-block-components-checkout-place-order-button").click();
+    await page.waitForURL(/webpay3gint\.transbank\.cl|tbk\.cl/, {
+        timeout: 45_000
+    });
+}

--- a/tests/e2e/helpers/concurrent.js
+++ b/tests/e2e/helpers/concurrent.js
@@ -1,0 +1,67 @@
+import {
+    login,
+    addProductToCart,
+    goThroughCheckoutWithWebpay
+} from "./checkout.js";
+import { fillCardAndAuthenticate } from "./webpay-form.js";
+import { isPaymentError } from "./assertions.js";
+
+const isReturnUrl = (url) => {
+    const s = url.toString();
+
+    return s.includes("wc-api") && s.includes("token_ws=");
+};
+
+export async function runCheckoutFlow(page) {
+    await login(page);
+    await addProductToCart(page);
+    await goThroughCheckoutWithWebpay(page);
+    await fillCardAndAuthenticate(page);
+}
+
+export async function holdReturnRequests(context) {
+    let releaseReturns;
+    let returnsReleased = false;
+    const returnsCanContinue = new Promise((resolve) => {
+        releaseReturns = resolve;
+    });
+    const commerceReturns = [];
+
+    await context.route(isReturnUrl, async (route) => {
+        const requestUrl = route.request().url();
+        commerceReturns.push(requestUrl);
+        console.log(
+            `[INTERCEPTOR] Return #${commerceReturns.length} intercepted: ${requestUrl}`
+        );
+
+        if (!returnsReleased) {
+            await returnsCanContinue;
+        }
+
+        await route.continue();
+    });
+
+    return {
+        commerceReturns,
+        release() {
+            returnsReleased = true;
+            releaseReturns();
+        }
+    };
+}
+
+export function hasNavigatedPastValidation(page) {
+    try {
+        return !page.url().includes("wc-api");
+    } catch {
+        return false;
+    }
+}
+
+export async function hasErrorContent(page) {
+    try {
+        return isPaymentError(page.url());
+    } catch {
+        return false;
+    }
+}

--- a/tests/e2e/helpers/database.js
+++ b/tests/e2e/helpers/database.js
@@ -1,0 +1,81 @@
+import mysql from "mysql2/promise";
+
+const DB_CONFIG = {
+    host: process.env.DB_HOST,
+    port: Number.parseInt(process.env.DB_PORT, 10),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME
+};
+
+let pool;
+
+function getPool() {
+    if (!pool) {
+        pool = mysql.createPool({
+            ...DB_CONFIG,
+            waitForConnections: true,
+            connectionLimit: 5
+        });
+    }
+
+    return pool;
+}
+
+export async function closePool() {
+    if (pool) {
+        await pool.end();
+        pool = null;
+    }
+}
+
+const queryScalar = async (sql, params = []) => {
+    const [rows] = await getPool().execute(sql, params);
+
+    return rows[0] ? Object.values(rows[0])[0] : null;
+};
+
+export async function holdLock(key) {
+    const connection = await mysql.createConnection(DB_CONFIG);
+    const [rows] = await connection.execute(
+        "SELECT GET_LOCK(?, 0) AS acquired",
+        [key]
+    );
+    const acquired = rows[0].acquired === 1;
+
+    if (!acquired) {
+        await connection.end();
+        throw new Error(`Could not acquire lock for key: ${key}`);
+    }
+
+    return {
+        release: async () => {
+            await connection.execute("SELECT RELEASE_LOCK(?)", [key]);
+            await connection.end();
+        }
+    };
+}
+
+export async function isLockHeld(key) {
+    const result = await queryScalar("SELECT IS_USED_LOCK(?)", [key]);
+
+    return result !== null;
+}
+
+export async function getOrderCountByToken(token) {
+    const result = await queryScalar(
+        "SELECT COUNT(*) FROM wp_wc_orders WHERE id IN (SELECT order_id FROM wp_webpay_rest_transactions WHERE token = ?) AND type = 'shop_order'",
+        [token]
+    );
+
+    return Number(result);
+}
+
+export async function getTransactionStatus(token) {
+    const result = await queryScalar(
+        "SELECT status FROM wp_webpay_rest_transactions WHERE token = ? LIMIT 1",
+        [token]
+    );
+
+    return result;
+}

--- a/tests/e2e/helpers/webpay-form.js
+++ b/tests/e2e/helpers/webpay-form.js
@@ -1,0 +1,73 @@
+import { expect } from "@playwright/test";
+
+const TEST_CARD = {
+    number: "4051885600446623",
+    expiry: "12/30",
+    cvv: "123"
+};
+
+const BANK_SIM = {
+    rut: "11.111.111-1",
+    password: "123"
+};
+
+const S = {
+    tarjetasBtn: "#tarjetas",
+    cardNumber: "#card-number",
+    cardExpiry: "#card-exp",
+    cardCvv: "#card-cvv",
+    payButton: "app-tarjeta form button.submit",
+    bankRut: "#rutClient",
+    bankPassword: "#passwordClient",
+    bankAccept: 'input[type="submit"][value="Aceptar"]',
+    resultVci: "#vci",
+    continueBtn: 'input[type="submit"][value="Continuar"]'
+};
+
+export async function fillCardAndAuthenticate(page) {
+    await page
+        .locator(S.tarjetasBtn)
+        .waitFor({ state: "visible", timeout: 15_000 });
+    await page.locator(S.tarjetasBtn).click();
+
+    await page
+        .locator(S.cardNumber)
+        .waitFor({ state: "visible", timeout: 15_000 });
+    await page.locator(S.cardNumber).fill(TEST_CARD.number);
+
+    await page.locator(S.cardNumber).blur();
+
+    await page
+        .locator(S.cardExpiry)
+        .waitFor({ state: "visible", timeout: 15_000 });
+    await page.locator(S.cardExpiry).fill(TEST_CARD.expiry);
+
+    await page
+        .locator(S.cardCvv)
+        .waitFor({ state: "visible", timeout: 10_000 });
+    await page.locator(S.cardCvv).fill(TEST_CARD.cvv);
+
+    await page.locator(S.payButton).click();
+
+    await page
+        .locator(S.bankRut)
+        .waitFor({ state: "visible", timeout: 30_000 });
+    await page.locator(S.bankRut).fill(BANK_SIM.rut);
+    await page.locator(S.bankPassword).fill(BANK_SIM.password);
+    await page.locator(S.bankAccept).click();
+
+    await page
+        .locator(S.resultVci)
+        .waitFor({ state: "visible", timeout: 30_000 });
+}
+
+export async function continueToCommerce(page) {
+    await expect(page.locator(S.resultVci)).toHaveValue("TSY", {
+        timeout: 30_000
+    });
+    await page.locator(S.continueBtn).click();
+}
+
+export function extractTokenFromUrl(url) {
+    return /token_ws=([^&]+)/.exec(url)?.[1] ?? null;
+}

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "transbank-woocommerce-e2e",
+    "version": "1.0.0",
+    "private": true,
+    "type": "module",
+    "description": "E2E tests for Transbank WooCommerce plugin",
+    "scripts": {
+        "setup": "pnpm playwright install chromium",
+        "test": "pnpm playwright test --headed",
+        "test:webpay-plus": "pnpm playwright test webpay-plus --headed",
+        "test:debug": "pnpm playwright test --debug",
+        "report": "pnpm playwright show-report"
+    },
+    "devDependencies": {
+        "@playwright/test": "1.61.0",
+        "dotenv": "16.5.0",
+        "mysql2": "3.22.5"
+    }
+}

--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -1,0 +1,24 @@
+// @ts-check
+import "dotenv/config";
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+    testDir: "./specs",
+    fullyParallel: false,
+    workers: 1,
+    timeout: 120_000,
+    expect: {
+        timeout: 15_000
+    },
+    retries: 0,
+    reporter: [["html", { open: "never" }], ["list"]],
+    use: {
+        baseURL: process.env.BASE_URL,
+        ignoreHTTPSErrors: true,
+        trace: "retain-on-failure",
+        screenshot: "only-on-failure",
+        video: "retain-on-failure",
+        actionTimeout: 15_000,
+        navigationTimeout: 45_000
+    }
+});

--- a/tests/e2e/pnpm-lock.yaml
+++ b/tests/e2e/pnpm-lock.yaml
@@ -1,0 +1,156 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.61.0
+        version: 1.61.0
+      dotenv:
+        specifier: 16.5.0
+        version: 16.5.0
+      mysql2:
+        specifier: 3.22.5
+        version: 3.22.5(@types/node@26.0.1)
+
+packages:
+
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@types/node@26.0.1':
+    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
+  dotenv@16.5.0:
+    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
+    engines: {node: '>=12'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
+  mysql2@3.22.5:
+    resolution: {integrity: sha512-95uZ2TrPWAZdwpB3vvvDbmEMcNG8yIeNCyu6GUcr/QnWEE/wXm7+mhOCsdQfWQDTV7qYT/PDUZ4U4UPP4AsXqQ==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
+
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sql-escaper@1.3.3:
+    resolution: {integrity: sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
+
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
+snapshots:
+
+  '@playwright/test@1.61.0':
+    dependencies:
+      playwright: 1.61.0
+
+  '@types/node@26.0.1':
+    dependencies:
+      undici-types: 8.3.0
+
+  aws-ssl-profiles@1.1.2: {}
+
+  denque@2.1.0: {}
+
+  dotenv@16.5.0: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  is-property@1.0.2: {}
+
+  long@5.3.2: {}
+
+  lru.min@1.1.4: {}
+
+  mysql2@3.22.5(@types/node@26.0.1):
+    dependencies:
+      '@types/node': 26.0.1
+      aws-ssl-profiles: 1.1.2
+      denque: 2.1.0
+      generate-function: 2.3.1
+      iconv-lite: 0.7.2
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.3.3
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
+
+  playwright-core@1.61.0: {}
+
+  playwright@1.61.0:
+    dependencies:
+      playwright-core: 1.61.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  safer-buffer@2.1.2: {}
+
+  sql-escaper@1.3.3: {}
+
+  undici-types@8.3.0: {}

--- a/tests/e2e/specs/webpay-plus/payment-validate/concurrent-lock-success.spec.js
+++ b/tests/e2e/specs/webpay-plus/payment-validate/concurrent-lock-success.spec.js
@@ -1,0 +1,156 @@
+import { test, expect } from "@playwright/test";
+import {
+    continueToCommerce,
+    extractTokenFromUrl
+} from "../../../helpers/webpay-form.js";
+import {
+    getOrderCountByToken,
+    getTransactionStatus,
+    closePool
+} from "../../../helpers/database.js";
+import { expectValidResponse } from "../../../helpers/assertions.js";
+import {
+    runCheckoutFlow,
+    holdReturnRequests,
+    hasNavigatedPastValidation
+} from "../../../helpers/concurrent.js";
+
+const captureAndDuplicateReturn = async (context, page, returnHolder) => {
+    await continueToCommerce(page);
+
+    await expect
+        .poll(() => returnHolder.commerceReturns.length, {
+            message: "Waiting for first intercepted return",
+            timeout: 45_000,
+            intervals: [500]
+        })
+        .toBeGreaterThanOrEqual(1);
+
+    const commerceReturnUrl = returnHolder.commerceReturns[0];
+
+    const duplicatePage = await context.newPage();
+    const duplicateNavigation = duplicatePage.goto(commerceReturnUrl, {
+        waitUntil: "commit",
+        timeout: 45_000
+    });
+
+    await expect
+        .poll(() => returnHolder.commerceReturns.length, {
+            message: "Waiting for both returns to be intercepted",
+            timeout: 45_000,
+            intervals: [500]
+        })
+        .toBeGreaterThanOrEqual(2);
+
+    console.log(
+        `[INTERCEPTOR] Both returns intercepted (${returnHolder.commerceReturns.length}). Releasing...`
+    );
+    returnHolder.release();
+
+    await Promise.all([
+        page.waitForLoadState("load").catch(() => {}),
+        duplicateNavigation?.catch(() => {})
+    ]);
+
+    await Promise.all([
+        page.waitForLoadState("networkidle").catch(() => {}),
+        duplicatePage.waitForLoadState("networkidle").catch(() => {})
+    ]);
+
+    return duplicatePage;
+};
+
+const verifyBothPagesResolved = async (page, duplicatePage) => {
+    for (const { label, p } of [
+        { label: "Request 1 (original)", p: page },
+        { label: "Request 2 (duplicate)", p: duplicatePage }
+    ]) {
+        await expect
+            .poll(() => hasNavigatedPastValidation(p), {
+                timeout: 45_000,
+                intervals: [1_000],
+                message: `${label}: waiting for navigation to finish`
+            })
+            .toBe(true);
+
+        const { confirmation, paymentErr } = await expectValidResponse(
+            p,
+            label
+        );
+        console.log(
+            `[INTERCEPTOR] ${label}: url=${p.url()}, confirmation=${confirmation}, payment_error=${paymentErr}`
+        );
+    }
+};
+
+test.describe("Webpay Plus — Lock prevents duplicate orders", () => {
+    test("Both requests resolve without error when the return URL receives the same token twice", async ({
+        browser,
+        baseURL
+    }) => {
+        console.log("═══ START: Lock prevents duplicate orders ═══");
+        const context = await browser.newContext({
+            baseURL,
+            ignoreHTTPSErrors: true
+        });
+        const returnHolder = await holdReturnRequests(context);
+        const page = await context.newPage();
+        let duplicatePage;
+
+        try {
+            await test.step("Full checkout up to Transbank", async () =>
+                runCheckoutFlow(page));
+
+            await test.step("Capture return URL and open duplicate request", async () => {
+                duplicatePage = await captureAndDuplicateReturn(
+                    context,
+                    page,
+                    returnHolder
+                );
+            });
+
+            await test.step("Verify that 2 requests arrived with the same token", async () => {
+                expect(returnHolder.commerceReturns).toHaveLength(2);
+
+                const tokens =
+                    returnHolder.commerceReturns.map(extractTokenFromUrl);
+                expect(tokens[0]).toBeTruthy();
+                expect(tokens[0]).toBe(tokens[1]);
+                console.log(`[INTERCEPTOR] token_ws: ${tokens[0]}`);
+            });
+
+            await test.step("Verify both requests show a valid response", async () => {
+                await verifyBothPagesResolved(page, duplicatePage);
+            });
+
+            await test.step("Verify exactly 1 order was created in the database", async () => {
+                const token = extractTokenFromUrl(
+                    returnHolder.commerceReturns[0]
+                );
+                expect(
+                    token,
+                    "Could not extract token from the return URL"
+                ).toBeTruthy();
+
+                const orderCount = await getOrderCountByToken(token);
+                const txStatus = await getTransactionStatus(token);
+                console.log(
+                    `[INTERCEPTOR] Orders: ${orderCount}, transaction status: ${txStatus}`
+                );
+
+                expect(
+                    orderCount,
+                    "There must be exactly 1 order for this token"
+                ).toBe(1);
+                expect(
+                    txStatus,
+                    "Transaction must be in APPROVED state"
+                ).toBe("approved");
+            });
+        } finally {
+            console.log("═══ END: Lock prevents duplicate orders ═══");
+            await closePool();
+            await context.close();
+        }
+    });
+});

--- a/tests/e2e/specs/webpay-plus/payment-validate/concurrent-retry-failure.spec.js
+++ b/tests/e2e/specs/webpay-plus/payment-validate/concurrent-retry-failure.spec.js
@@ -1,0 +1,134 @@
+import { test, expect } from "@playwright/test";
+import {
+    continueToCommerce,
+    extractTokenFromUrl
+} from "../../../helpers/webpay-form.js";
+import {
+    getOrderCountByToken,
+    holdLock,
+    isLockHeld,
+    closePool
+} from "../../../helpers/database.js";
+import { expectPaymentError } from "../../../helpers/assertions.js";
+import {
+    runCheckoutFlow,
+    holdReturnRequests,
+    hasErrorContent
+} from "../../../helpers/concurrent.js";
+
+const captureAndDuplicateWithLock = async (context, page, returnHolder) => {
+    await continueToCommerce(page);
+
+    await expect
+        .poll(() => returnHolder.commerceReturns.length, {
+            message: "Waiting for first intercepted return",
+            timeout: 45_000,
+            intervals: [500]
+        })
+        .toBeGreaterThanOrEqual(1);
+
+    const commerceReturnUrl = returnHolder.commerceReturns[0];
+
+    const duplicatePage = await context.newPage();
+    const duplicateNavigation = duplicatePage.goto(commerceReturnUrl, {
+        waitUntil: "commit",
+        timeout: 120_000
+    });
+
+    await expect
+        .poll(() => returnHolder.commerceReturns.length, {
+            message: "Waiting for both returns to be intercepted",
+            timeout: 45_000,
+            intervals: [500]
+        })
+        .toBeGreaterThanOrEqual(2);
+
+    const token = extractTokenFromUrl(commerceReturnUrl);
+    expect(token, "Could not extract token from the return URL").toBeTruthy();
+
+    const externalLock = await holdLock(token);
+    expect(
+        await isLockHeld(token),
+        "External lock must be active before releasing returns"
+    ).toBe(true);
+    console.log(`[INTERCEPTOR] External lock acquired for token: ${token}`);
+
+    console.log(
+        `[INTERCEPTOR] Both returns intercepted (${returnHolder.commerceReturns.length}). Releasing simultaneously...`
+    );
+    returnHolder.release();
+
+    duplicateNavigation.catch((err) => {
+        console.log(`[INTERCEPTOR] Duplicate navigation error: ${err.message}`);
+    });
+
+    return { duplicatePage, externalLock };
+};
+
+test.describe("Webpay Plus — Max retries exhausted", () => {
+    test(
+        "Duplicate request shows error after retries exhaust",
+        { timeout: 120_000 },
+        async ({ browser, baseURL }) => {
+            console.log("═══ START: Max retries exhausted ═══");
+            const context = await browser.newContext({
+                baseURL,
+                ignoreHTTPSErrors: true
+            });
+            const returnHolder = await holdReturnRequests(context);
+            const page = await context.newPage();
+            let duplicatePage;
+            let externalLock;
+
+            try {
+                await test.step("Full checkout up to Transbank", async () =>
+                    runCheckoutFlow(page));
+
+                await test.step("Capture return URL, duplicate request and acquire external lock", async () => {
+                    ({ duplicatePage, externalLock } =
+                        await captureAndDuplicateWithLock(
+                            context,
+                            page,
+                            returnHolder
+                        ));
+                });
+
+                const checkErrorContent = () => hasErrorContent(duplicatePage);
+
+                await test.step("Wait for Request B retries to exhaust", async () => {
+                    await expect
+                        .poll(checkErrorContent, {
+                            timeout: 60_000,
+                            intervals: [1_000],
+                            message: "Waiting for Request B error page to render"
+                        })
+                        .toBe(true);
+                });
+
+                await test.step("Verify Request B shows a payment error (not a fatal error)", async () => {
+                    await expectPaymentError(duplicatePage);
+                    console.log(
+                        `[INTERCEPTOR] Request B (duplicate): url=${duplicatePage.url()}, payment_error=true`
+                    );
+                });
+
+                await test.step("Verify no duplicate order was created", async () => {
+                    const token = extractTokenFromUrl(
+                        returnHolder.commerceReturns[0]
+                    );
+                    const orderCount = await getOrderCountByToken(token);
+                    console.log(`[INTERCEPTOR] Orders for this token: ${orderCount}`);
+                    expect(
+                        orderCount,
+                        "At most 1 order must exist (no duplicate from Request B)"
+                    ).toBeLessThanOrEqual(1);
+                });
+            } finally {
+                await externalLock?.release();
+                console.log("═══ END: Max retries exhausted ═══");
+                await closePool();
+                await context.close();
+            }
+        }
+    );
+});

--- a/tests/e2e/specs/webpay-plus/payment-validate/concurrent-retry-success.spec.js
+++ b/tests/e2e/specs/webpay-plus/payment-validate/concurrent-retry-success.spec.js
@@ -1,0 +1,134 @@
+import { test, expect } from "@playwright/test";
+import {
+    continueToCommerce,
+    extractTokenFromUrl
+} from "../../../helpers/webpay-form.js";
+import {
+    getOrderCountByToken,
+    getTransactionStatus,
+    holdLock,
+    isLockHeld,
+    closePool
+} from "../../../helpers/database.js";
+import { expectOrderConfirmation } from "../../../helpers/assertions.js";
+import {
+    runCheckoutFlow,
+    holdReturnRequests,
+    hasNavigatedPastValidation
+} from "../../../helpers/concurrent.js";
+
+const acquireExternalLock = async (returnHolder) => {
+    const returnUrl = returnHolder.commerceReturns[0];
+    const token = extractTokenFromUrl(returnUrl);
+    expect(token, "Could not extract token from the return URL").toBeTruthy();
+    console.log(`[INTERCEPTOR] Token captured: ${token}`);
+
+    const externalLock = await holdLock(token);
+    expect(
+        await isLockHeld(token),
+        "External lock must be active before releasing the return"
+    ).toBe(true);
+    console.log("[INTERCEPTOR] External lock acquired, releasing return request...");
+
+    returnHolder.release();
+
+    return externalLock;
+};
+
+const waitForRetryAndReleaseLock = async (externalLock, page) => {
+    await new Promise((r) => setTimeout(r, 6_000));
+
+    await externalLock.release();
+    console.log(
+        "[INTERCEPTOR] External lock released, the internal retry should acquire the lock now"
+    );
+
+    await expect
+        .poll(() => hasNavigatedPastValidation(page), {
+            timeout: 60_000,
+            intervals: [1_000],
+            message: "Waiting for the retry to finish processing"
+        })
+        .toBe(true);
+};
+
+test.describe("Webpay Plus — Retry when lock is busy", () => {
+    test("Internal retry processes the transaction after GET_LOCK times out", async ({
+        browser,
+        baseURL
+    }) => {
+        console.log("═══ START: Retry when lock is busy ═══");
+        const context = await browser.newContext({
+            baseURL,
+            ignoreHTTPSErrors: true
+        });
+        const returnHolder = await holdReturnRequests(context);
+        const page = await context.newPage();
+        let externalLock;
+
+        try {
+            await test.step("Full checkout up to Transbank", async () =>
+                runCheckoutFlow(page));
+
+            await test.step("Capture return URL and acquire external lock", async () => {
+                await continueToCommerce(page);
+
+                const isIntercepted = () => returnHolder.commerceReturns.length > 0;
+
+                await expect
+                    .poll(isIntercepted, {
+                        message: "Waiting for intercepted return",
+                        timeout: 45_000,
+                        intervals: [500]
+                    })
+                    .toBe(true);
+
+                externalLock = await acquireExternalLock(returnHolder);
+            });
+
+            await test.step("Wait for GET_LOCK timeout and release lock for the retry", async () => {
+                await waitForRetryAndReleaseLock(externalLock, page);
+                externalLock = null;
+            });
+
+            await test.step("Verify the page shows order confirmation", async () => {
+                await page.waitForURL(/order-received/, {
+                    timeout: 30_000,
+                    waitUntil: "load"
+                });
+                await expectOrderConfirmation(page);
+                console.log(
+                    `[INTERCEPTOR] Confirmation: url=${page.url()}`
+                );
+            });
+
+            await test.step("Verify exactly 1 order was created in the database", async () => {
+                const token = extractTokenFromUrl(returnHolder.commerceReturns[0]);
+                expect(
+                    token,
+                    "Could not extract token from the return URL"
+                ).toBeTruthy();
+
+                const orderCount = await getOrderCountByToken(token);
+                const txStatus = await getTransactionStatus(token);
+                console.log(
+                    `[INTERCEPTOR] Orders: ${orderCount}, transaction status: ${txStatus}`
+                );
+
+                expect(
+                    orderCount,
+                    "There must be exactly 1 order for this token"
+                ).toBe(1);
+                expect(
+                    txStatus,
+                    "Transaction must be in APPROVED state"
+                ).toBe("approved");
+            });
+        } finally {
+            await externalLock?.release();
+            console.log("═══ END: Retry when lock is busy ═══");
+            await closePool();
+            await context.close();
+        }
+    });
+});

--- a/tests/e2e/specs/webpay-plus/payment-validate/successful-payment.spec.js
+++ b/tests/e2e/specs/webpay-plus/payment-validate/successful-payment.spec.js
@@ -1,0 +1,42 @@
+import { test } from "@playwright/test";
+import {
+    login,
+    addProductToCart,
+    goThroughCheckoutWithWebpay,
+} from "../../../helpers/checkout.js";
+import {
+    fillCardAndAuthenticate,
+    continueToCommerce,
+} from "../../../helpers/webpay-form.js";
+import { expectOrderConfirmation } from "../../../helpers/assertions.js";
+
+test.describe("Webpay Plus — Normal payment flow", () => {
+    test("Authorized payment shows order confirmation", async ({ page }) => {
+        console.log("═══ START: Normal payment flow ═══");
+
+        await test.step("Login", async () => {
+            await login(page);
+        });
+
+        await test.step("Add product to cart", async () => {
+            await addProductToCart(page);
+        });
+
+        await test.step("Complete checkout with Webpay Plus", async () => {
+            await goThroughCheckoutWithWebpay(page);
+        });
+
+        await test.step("Complete payment form on Transbank", async () => {
+            await fillCardAndAuthenticate(page);
+        });
+
+        await test.step("Return to commerce and verify confirmation", async () => {
+            await continueToCommerce(page);
+            await page.waitForURL(/order-received/, { timeout: 45_000 });
+            await expectOrderConfirmation(page);
+            console.log(`[INTERCEPTOR] Confirmation: url=${page.url()}`);
+        });
+
+        console.log("═══ END: Normal payment flow ═══");
+    });
+});


### PR DESCRIPTION
## Description
When two simultaneous payment requests arrive with the same token, the duplicate request waits until the original finishes processing. If the lock is released in time, the duplicate detects the transaction was already processed and redirects the customer to the actual payment result. If the wait times out, the controller retries internally up to 3 times within the same request. If all retries are exhausted, it shows a generic error page to avoid blocking the customer indefinitely. Both requests end with the same view for the customer under normal conditions.

## Changes
 - Reduced the GET_LOCK timeout in MySqlNamedLock from 10s to 5s, so each attempt waits a shorter window before the controller decides to retry, instead of holding a single longer wait per request.
 - Added an internal retry mechanism (acquireWebpayReturnLockWithRetries in CommitWebpayController): when GET_LOCK times out, the controller retries immediately within the same PHP request via a for loop, up to 3 additional times (4 attempts total). If all attempts are exhausted, an EcommerceException is thrown and the customer sees an error page.
 - The 5-second timeout was defined considering that the bottleneck of the first request is the HTTP call to the Transbank API to commit the transaction. Under normal conditions it responds in 1–3 seconds, and under high latency or load it could take up to 5 seconds. If the lock is not released within that window, the internal retry attempts GET_LOCK again immediately.
 - Added a Playwright e2e suite (tests/e2e/) covering the WooCommerce payment concurrency flow: successful payment, lock preventing duplicate orders, retry succeeding after a busy lock, and retries exhausted under sustained contention.

## Test
 - WebPay Normal Payment Flow
<img width="2548" height="1314" alt="webpay-normal-payment-flow" src="https://github.com/user-attachments/assets/72c1d3a6-536e-4ac9-84bf-856847d83067" />

 - WebPay Lock Payment Flow
<img width="2548" height="1314" alt="webpay-lock-prevents-duplicate-orders" src="https://github.com/user-attachments/assets/7752fe86-27c9-4759-9269-f2a6cc72441a" />

 - WebPay Retry On Lock Payment Flow
<img width="2548" height="1314" alt="webpay-retry-on-lock-timeout" src="https://github.com/user-attachments/assets/b809b356-0c26-40a5-906d-be7af32927d2" />

 - WebPay Max Retries Exhausted Payment Flow
<img width="2548" height="1314" alt="webpay-max-retries-exhausted" src="https://github.com/user-attachments/assets/1ee2d0a6-6e99-4318-999c-033ca835ae54" />

- Log
[log_transbank_6a43c3532acdb2.15844023-2026-06-30.log](https://github.com/user-attachments/files/29511279/log_transbank_6a43c3532acdb2.15844023-2026-06-30.log)

## Diagrams
- Get Lock Timeout Explained: Timeline Diagram
<img width="2444" height="2645" alt="getlock_sequence" src="https://github.com/user-attachments/assets/a62606b7-ce8d-41d9-976e-c6ed68b1870f" />

- WebPay Concurrent Sequence: Sequence Diagram
<img width="2246" height="5772" alt="concurrence_sequence" src="https://github.com/user-attachments/assets/56b7324f-5937-4990-9bd5-6fc975390089" />

- WebPay Concurrent Flow: Flow Diagram
<img width="4088" height="2427" alt="concurrence_flow" src="https://github.com/user-attachments/assets/39394d59-e9f3-4009-93b4-8f41e9b0d180" />

