### PR TITLE
feat: refine notices visualization in legacy woocommerce versions

### DIFF
--- a/plugin/src/Controllers/CommitWebpayController.php
+++ b/plugin/src/Controllers/CommitWebpayController.php
@@ -11,6 +11,7 @@ use Transbank\Webpay\WebpayPlus\Responses\TransactionCommitResponse;
 use Transbank\WooCommerce\WebpayRest\Infrastructure\Lock\MySqlNamedLock;
 use Transbank\WooCommerce\WebpayRest\Exceptions\MySqlNamedLockException;
 use Transbank\WooCommerce\WebpayRest\Helpers\TbkFactory;
+use Transbank\WooCommerce\WebpayRest\Helpers\BlocksHelper;
 use Transbank\WooCommerce\WebpayRest\Services\EcommerceService;
 use Transbank\WooCommerce\WebpayRest\Services\TransactionService;
 
@@ -549,6 +550,7 @@ class CommitWebpayController
             'transbankResponse' => null
         ]);
         $this->log->logError(self::ERROR_MESSAGES[$errorCode]);
+        BlocksHelper::addLegacyNotices(self::ERROR_MESSAGES[$errorCode], 'error');
         $this->redirect($this->getCheckoutUrlWithError($errorCode));
     }
 

--- a/plugin/src/Controllers/FinishOneclickController.php
+++ b/plugin/src/Controllers/FinishOneclickController.php
@@ -78,7 +78,10 @@ class FinishOneclickController
             $this->log->logError('Error procesando el retorno de inscripción Oneclick', [
                 'error' => $e->getMessage(),
             ]);
-            BlocksHelper::addLegacyNotices($e->getMessage(), 'error');
+            BlocksHelper::addLegacyNotices(
+                __('Ocurrió un error al ejecutar la inscripción.', 'transbank_wc_plugin'),
+                'error'
+            );
             $this->redirectUser('checkout', BlocksHelper::ONECLICK_FINISH_ERROR);
         }
     }

--- a/plugin/src/Controllers/FinishOneclickController.php
+++ b/plugin/src/Controllers/FinishOneclickController.php
@@ -78,6 +78,7 @@ class FinishOneclickController
             $this->log->logError('Error procesando el retorno de inscripción Oneclick', [
                 'error' => $e->getMessage(),
             ]);
+            BlocksHelper::addLegacyNotices($e->getMessage(), 'error');
             $this->redirectUser('checkout', BlocksHelper::ONECLICK_FINISH_ERROR);
         }
     }
@@ -120,7 +121,7 @@ class FinishOneclickController
         if (!$ins) {
             throw new EcommerceException('No se encontró la inscripción para el token proporcionado.');
         }
-        BlocksHelper::addLegacyNotices('Inscripción abortada desde el formulario. Puedes reintentar la inscripción. ', 'warning');
+        BlocksHelper::addLegacyNotices('Inscripción abortada desde el formulario. Puedes reintentar la inscripción. ', 'error');
         $this->inscriptionService->update($ins->id, [
             'status' => TbkConstants::INSCRIPTIONS_STATUS_FAILED
         ]);


### PR DESCRIPTION
## Description
When a customer cancels, times out, or gets rejected during a WebPay or Oneclick payment, the plugin redirects them back to checkout to let them know what happened and that they can retry. On stores still using the classic checkout layout (the default on older WooCommerce versions, including the plugin's declared minimum of 7.0), that message did not show at all in some of these scenarios. The customer was silently sent back to checkout with no explanation, which looks like the store just failed without telling them why. This affected the checkout using WebPay Plus REST, and the "Anular"/cancel and error/rejection flows for Oneclick's card enrollment. Stores already on newer WooCommerce versions using the block based checkout layout by default were not affected, since that layout has its own separate way of showing the message. This fix brings the classic checkout up to par with the block based one, so merchants on older WooCommerce versions get the same customer feedback as everyone else.

## Changes
 - Added BlocksHelper::addLegacyNotices() to CommitWebpayController::setPaymentErrorPage(), the single funnel every WebPay failure path (aborted, timeout, form error, already processed, generic exception) redirects through. Since every code handled there (8 to 13) is always of type 'error', and the message text already lived in self::ERROR_MESSAGES, one call covers all of them without duplicating it per catch site.
 - Added BlocksHelper::addLegacyNotices() to the top level catch in FinishOneclickController::process(), which previously redirected straight to checkout with transbank_status=5 on invalid/missing Oneclick return params, an unrecognized flow, or an inscription not found in handleAbortedFlow, all without ever notifying the customer on classic checkout.
 - Fixed handleAbortedFlow()'s existing addLegacyNotices() call, which used 'warning' as the notice type. WooCommerce's wc_add_notice()/wc_print_notices() only recognize error, success, and notice (unchanged since WC 2.1 through the latest 10.x). 'warning' gets stored in the session but is never iterated over when notices are printed, so the cancellation message was silently dropped even before this PR's other fixes. Changed to 'error', matching the type the block checkout JS already uses for this same status code, so the message is now consistent between both checkout modes.

## Test
- Checkout
  - Webpay
    - Success
      <img width="2548" height="1312" alt="webpay-plus-success" src="https://github.com/user-attachments/assets/72f3c1bf-c03d-437a-93f2-da44d1176d42" />
    - Aborted
      <img width="2548" height="1312" alt="webpay-plus-aborted" src="https://github.com/user-attachments/assets/ff46b2bb-4851-419e-9b93-d863aff8a073" />
    - Rejected
      <img width="2548" height="1312" alt="webpay-plus-rejected" src="https://github.com/user-attachments/assets/a1838873-f9cb-42b9-9b46-f1d8c9e22cb2" />
  - One Click
    - Success
      <img width="2548" height="1312" alt="one-click-success" src="https://github.com/user-attachments/assets/484c1fb2-e788-4148-b71b-f060d301a247" />
    - Aborted
      <img width="2548" height="1312" alt="one-click-aborted" src="https://github.com/user-attachments/assets/7da51f2c-c35c-4eee-bfe4-db1e60761c29" />
    - Rejected
      <img width="2548" height="1312" alt="one-click-rejected" src="https://github.com/user-attachments/assets/4395d36e-ce37-4437-a67d-5ee8fd521e9e" />
- My Account
  - One Click
    - Success
      <img width="2548" height="1312" alt="my-account-success" src="https://github.com/user-attachments/assets/c2a0309d-77c9-45f3-94b9-a1adb441f3c0" />
    - Aborted
      <img width="2548" height="1312" alt="my-account-aborted" src="https://github.com/user-attachments/assets/047bf570-6fe0-4bf8-8a4e-0ef5bd87ab97" />
    - Rejected
      <img width="2548" height="1312" alt="my-account-rejected" src="https://github.com/user-attachments/assets/bc4cff45-ae12-4905-b83a-d5d847057c42" />
    - Deleted
      <img width="2548" height="1312" alt="my-account-deleted" src="https://github.com/user-attachments/assets/736645a2-86da-447b-a352-d386d0924b4d" />
